### PR TITLE
[WIP] Fix TickTask not being registered correctly

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/core/TickTask.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/TickTask.kt
@@ -29,12 +29,12 @@ class TickTask(private var ticks: Int = 0, private val task: () -> Unit) {
         if (event.phase != TickEvent.Phase.START) return
         if (ticks <= 0) {
             task()
-            MinecraftForge.EVENT_BUS.unregister(this)
+            MinecraftForge.EVENT_BUS.unregister(this.javaClass)
         }
         ticks--
     }
 
     init {
-        MinecraftForge.EVENT_BUS.register(this)
+        MinecraftForge.EVENT_BUS.register(this.javaClass)
     }
 }


### PR DESCRIPTION
This caused a huge amount of logs being dumped onto the console, causing the main thread to hang in excess of 5 seconds. Based on the limited testing that I did, the issue was not fixed by this commit, but it helped mitigate.