### PR TITLE
Rename score calc methods, auto change based on version

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/Skytils.kt
+++ b/src/main/kotlin/skytils/skytilsmod/Skytils.kt
@@ -239,15 +239,19 @@ class Skytils {
         usingLabymod = Loader.isModLoaded("labymod")
         usingNEU = Loader.isModLoaded("notenoughupdates")
 
-        if (usingDungeonRooms && Loader.instance().indexedModList["dungeonrooms"]!!.version.startsWith("2")) {
-            runCatching {
-                Class.forName("io.github.quantizr.utils.Utils").also {
-                    ScoreCalculation.drmRoomScanMethod = MethodHandles.publicLookup().findStatic(
-                        it, "roomList", MethodType.methodType(
-                            List::class.java
+        if (usingDungeonRooms) {
+            if (Loader.instance().indexedModList["dungeonrooms"]!!.version.startsWith("2.0")) {
+                runCatching {
+                    Class.forName("io.github.quantizr.utils.Utils").also {
+                        ScoreCalculation.drmRoomScanMethod = MethodHandles.publicLookup().findStatic(
+                            it, "roomList", MethodType.methodType(
+                                List::class.java
+                            )
                         )
-                    )
+                    }
                 }
+            } else {
+                config.scoreCalculationMethod = 0;
             }
         }
 

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -199,9 +199,9 @@ class Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sorting
 
     @Property(
         type = PropertyType.SELECTOR, name = "Score Calculation Method",
-        description = "New method requires Dungeon Rooms Mod version 2.0",
+        description = "\"Special\" method only works with Dungeon Rooms Mod v2.0.0, for ANY other version use \"Standard\"\n§c\"Special\" method is use at your own risk.",
         category = "Dungeons", subcategory = "Score Calculation",
-        options = ["Old", "New"]
+        options = ["Standard", "Special"]
     )
     var scoreCalculationMethod = 0
 


### PR DESCRIPTION
Old and New is confusing cause new DRM needs Old method

People too lazy to change version back to old and I have to guide step by step so might as well just auto change to old method if booting up with non 2.0.0 version