### PR TITLE
Feature: Add Power Orb Lock minimum Duration

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -2365,6 +2365,8 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         addDependency("boxedTankColor", "boxedTanks")
         addDependency("boxedProtectedTeammatesColor", "boxedProtectedTeammates")
 
+        addDependency("powerOrbDuration", "powerOrbLock")
+
         addDependency("yangGlyphColor", "highlightYangGlyph")
         addDependency("nukekebiHeadColor", "highlightNukekebiHeads")
 

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1573,6 +1573,14 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var powerOrbLock = false
 
     @Property(
+        type = PropertyType.NUMBER, name = "Power Orb Lock Duration",
+        description = "Needs Power Orb Lock to be active. Allows overwriting a power orb, if it has less time left than this option.",
+        min = 1, max = 60,
+        category = "Miscellaneous", subcategory = "Quality of Life"
+    )
+    var powerOrbDuration = 10
+
+    @Property(
         type = PropertyType.SWITCH, name = "Prevent Log Spam",
         description = "Prevents your logs from being spammed with exceptions while on Hypixel.",
         category = "Miscellaneous", subcategory = "Quality of Life"

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1575,7 +1575,7 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     @Property(
         type = PropertyType.NUMBER, name = "Power Orb Lock Duration",
         description = "Needs Power Orb Lock to be active. Allows overwriting a power orb, if it has less time left than this option.",
-        min = 1, max = 60,
+        min = 1, max = 120,
         category = "Miscellaneous", subcategory = "Quality of Life"
     )
     var powerOrbDuration = 10


### PR DESCRIPTION
Power Orb Lock now does not prevent the player from placing another orb if the duration of said orb is below a configurable threshold.