### PR TITLE
Feature: Press Enter to confirm sign popups

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/Skytils.kt
+++ b/src/main/kotlin/skytils/skytilsmod/Skytils.kt
@@ -191,6 +191,7 @@ class Skytils {
             DungeonMap(),
             DungeonTimer(),
             EnchantNames(),
+            EnterToConfirmSignPopup(),
             FarmingFeatures(),
             FavoritePets(),
             GlintCustomizer(),

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1588,6 +1588,13 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var preventLogSpam = false
 
     @Property(
+        type = PropertyType.SWITCH, name = "Press Enter to confirm Sign Popups",
+        description = "Allows pressing enter to confirm a sign popup, such as the bazaar or auction house prices.",
+        category = "Miscellaneous", subcategory = "Quality of Life"
+    )
+    var pressEnterToConfirmSignQuestion = true
+
+    @Property(
         type = PropertyType.TEXT, name = "Protect Items Above Value",
         description = "Prevents you from dropping, salvaging, or selling items worth more than this value. Based on Lowest BIN price.",
         category = "Miscellaneous", subcategory = "Quality of Life",

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/EnterToConfirmSignPopup.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/EnterToConfirmSignPopup.kt
@@ -24,7 +24,11 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import org.lwjgl.input.Keyboard
 import skytils.skytilsmod.core.Config
 import skytils.skytilsmod.mixins.transformers.accessors.AccessorGuiEditSign
+import skytils.skytilsmod.utils.Utils
 
+/**
+ * This feature allows users to confirm sign popups in skyblock with the enter key instead of the done button or the escape key.
+ */
 class EnterToConfirmSignPopup {
 
     val prompts = listOf(
@@ -35,9 +39,13 @@ class EnterToConfirmSignPopup {
         "Your auction",
     )
 
+    /**
+     * EventListener for this feature.
+     */
     @SubscribeEvent
     fun onGuiKey(event: GuiScreenEvent.KeyboardInputEvent.Post) {
         if (!Config.pressEnterToConfirmSignQuestion) return
+        if (!Utils.inSkyblock) return
         val gui = event.gui as? GuiEditSign ?: return
         if (Keyboard.getEventKey() != Keyboard.KEY_RETURN) return
         val tile = (gui as AccessorGuiEditSign).tileSign

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/EnterToConfirmSignPopup.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/EnterToConfirmSignPopup.kt
@@ -1,0 +1,50 @@
+/*
+ * Skytils - Hypixel Skyblock Quality of Life Mod
+ * Copyright (C) 2022 Skytils
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package skytils.skytilsmod.features.impl.misc
+
+import net.minecraft.client.gui.inventory.GuiEditSign
+import net.minecraftforge.client.event.GuiScreenEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import org.lwjgl.input.Keyboard
+import skytils.skytilsmod.core.Config
+import skytils.skytilsmod.mixins.transformers.accessors.AccessorGuiEditSign
+
+class EnterToConfirmSignPopup {
+
+    val prompts = listOf(
+        "Enter query",
+        "auction bid",
+        "Enter amount",
+        "Enter price",
+        "Your auction",
+    )
+
+    @SubscribeEvent
+    fun onGuiKey(event: GuiScreenEvent.KeyboardInputEvent.Post) {
+        if (!Config.pressEnterToConfirmSignQuestion) return
+        val gui = event.gui as? GuiEditSign ?: return
+        if (Keyboard.getEventKey() != Keyboard.KEY_RETURN) return
+        val tile = (gui as AccessorGuiEditSign).tileSign
+        if (!tile.signText.asSequence().map { it.unformattedText }.zipWithNext().any { (first, second) ->
+                first == "^^^^^^^^^^^^^^^" && prompts.any { second == it }
+            }) return
+        gui.mc.displayGuiScreen(null)
+    }
+
+}


### PR DESCRIPTION
This feature allows users to use the enter key to confirm text sign popups. Currently this is limited with a explicit allow list for only signs that occur in the bazaar or auction house.