### PR TITLE
Fix typo

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/commands/impl/HollowWaypointCommand.kt
+++ b/src/main/kotlin/skytils/skytilsmod/commands/impl/HollowWaypointCommand.kt
@@ -54,7 +54,7 @@ object HollowWaypointCommand : BaseCommand("skytilshollowwaypoint", listOf("sthw
             }
             if (MiningFeatures.minesLoc.exists()) {
                 message.append(UTextComponent("§9Mines of Divan "))
-                message.append(copyMessage("Mines of Divan: MiningFeatures.minesLoc}"))
+                message.append(copyMessage("Mines of Divan: ${MiningFeatures.minesLoc}"))
                 message.append(removeMessage("/skytilshollowwaypoint remove internal_mines"))
             }
             if (MiningFeatures.balLoc.exists()) {


### PR DESCRIPTION
Add `${` before the variable to fix the string template in `HollowWaypointCommand`.

Currently, clicking on this chat message to copy the Mines of Divan coords in chat produces this message instead of the coordinates:
```
Mines of Divan: MiningFeatures.minesLoc}
```
This is because of a typo added in 495c9f53b0e6a29261c939909185ced8531c934b that replaced string concatenation with Kotlin string templates.