### PR TITLE
Add King Waypoint

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/commands/impl/HollowWaypointCommand.kt
+++ b/src/main/kotlin/skytils/skytilsmod/commands/impl/HollowWaypointCommand.kt
@@ -57,6 +57,11 @@ object HollowWaypointCommand : BaseCommand("skytilshollowwaypoint", listOf("sthw
                 message.append(copyMessage("Mines of Divan: ${MiningFeatures.minesLoc}"))
                 message.append(removeMessage("/skytilshollowwaypoint remove internal_mines"))
             }
+            if (MiningFeatures.kingLoc.exists()) {
+                message.append(UTextComponent("§6King Yolkar "))
+                message.append(copyMessage("King Yolkar: ${MiningFeatures.kingLoc}"))
+                message.append(removeMessage("/skytilshollowwaypoint remove internal_king"))
+            }
             if (MiningFeatures.balLoc.exists()) {
                 message.append(UTextComponent("§cKhazad-dûm "))
                 message.append(copyMessage("Khazad-dûm: ${MiningFeatures.balLoc}"))
@@ -112,6 +117,11 @@ object HollowWaypointCommand : BaseCommand("skytilshollowwaypoint", listOf("sthw
                                 MiningFeatures.minesLoc.locY = y
                                 MiningFeatures.minesLoc.locZ = (z - 200).coerceIn(0.0, 624.0)
                             }
+                            "internal_king" -> {
+                                MiningFeatures.kingLoc.locX = (x - 200).coerceIn(0.0, 624.0)
+                                MiningFeatures.kingLoc.locY = y
+                                MiningFeatures.kingLoc.locZ = (z - 200).coerceIn(0.0, 624.0)
+                            }
                             "internal_bal" -> {
                                 MiningFeatures.balLoc.locX = (x - 200).coerceIn(0.0, 624.0)
                                 MiningFeatures.balLoc.locY = y
@@ -135,6 +145,7 @@ object HollowWaypointCommand : BaseCommand("skytilshollowwaypoint", listOf("sthw
                             "internal_temple" -> MiningFeatures.templeLoc.reset()
                             "internal_den" -> MiningFeatures.denLoc.reset()
                             "internal_mines" -> MiningFeatures.minesLoc.reset()
+                            "internal_king" -> MiningFeatures.kingLoc.reset()
                             "internal_bal" -> MiningFeatures.balLoc.reset()
                             "internal_fairy" -> MiningFeatures.fairyLoc.reset()
                             else -> MiningFeatures.waypoints.remove(args[1])
@@ -148,6 +159,7 @@ object HollowWaypointCommand : BaseCommand("skytilshollowwaypoint", listOf("sthw
                     MiningFeatures.templeLoc.reset()
                     MiningFeatures.denLoc.reset()
                     MiningFeatures.minesLoc.reset()
+                    MiningFeatures.kingLoc.reset()
                     MiningFeatures.balLoc.reset()
                     MiningFeatures.fairyLoc.reset()
                     MiningFeatures.waypoints.clear()

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1003,6 +1003,13 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var crystalHollowWaypoints = false
 
     @Property(
+        type = PropertyType.SWITCH, name = "King Yolkar waypoint",
+        description = "Adds a waypoint for King Yolkar upon interacting with him",
+        category = "Mining", subcategory = "Crystal Hollows"
+    )
+    var kingYolkarWaypoint = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Crystal Hollows chat coordinates grabber",
         description = "When coordinates are shared in chat asks which one it is and displays a waypoint there and shows it on the map.",
         category = "Mining", subcategory = "Crystal Hollows"

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -178,6 +178,11 @@ class MiningFeatures {
             else if (xzMatcher.matches())
                 waypointChatMessage(xzMatcher.group("x"), "100", xzMatcher.group("z"))
         }
+        if ((Skytils.config.crystalHollowWaypoints || Skytils.config.crystalHollowMapPlaces) && Skytils.config.kingYolkarWaypoint && SBInfo.mode == SkyblockIsland.CrystalHollows.mode
+            && mc.thePlayer != null && unformatted.startsWith("[NPC] King Yolkar:")
+        ) {
+            kingLoc.set()
+        }
         if (formatted.startsWith("§r§cYou died")) {
             deadCount =
                 50 //this is to make sure the scoreboard has time to update and nothing moves halfway across the map
@@ -252,6 +257,20 @@ class MiningFeatures {
                     )
                 )
         )
+        val king = ChatComponentText("§6[King Yolkar] ").setChatStyle(
+            ChatStyle()
+                .setChatClickEvent(
+                    ClickEvent(
+                        ClickEvent.Action.RUN_COMMAND,
+                        "/skytilshollowwaypoint set internal_king $x $y $z"
+                    )
+                ).setChatHoverEvent(
+                    HoverEvent(
+                        HoverEvent.Action.SHOW_TEXT,
+                        ChatComponentText("§eset waypoint for King Yolkar")
+                    )
+                )
+        )
         val bal = ChatComponentText("§c[Khazad-dûm] ").setChatStyle(
             ChatStyle()
                 .setChatClickEvent(
@@ -301,6 +320,8 @@ class MiningFeatures {
             component.appendSibling(den)
         if (!minesLoc.exists())
             component.appendSibling(mines)
+        if (!kingLoc.exists())
+            component.appendSibling(king)
         if (!balLoc.exists())
             component.appendSibling(bal)
         if (!fairyLoc.exists())
@@ -371,6 +392,7 @@ class MiningFeatures {
             templeLoc.drawWaypoint("Jungle Temple", event.partialTicks)
             denLoc.drawWaypoint("Goblin Queen's Den", event.partialTicks)
             minesLoc.drawWaypoint("Mines of Divan", event.partialTicks)
+            kingLoc.drawWaypoint("King Yolkar",event.partialTicks)
             balLoc.drawWaypoint("Khazad-dûm", event.partialTicks)
             fairyLoc.drawWaypoint("Fairy Grotto", event.partialTicks)
             RenderUtil.renderWaypointText("Crystal Nucleus", 513.5, 107.0, 513.5, event.partialTicks)
@@ -445,6 +467,7 @@ class MiningFeatures {
         templeLoc.reset()
         denLoc.reset()
         minesLoc.reset()
+        kingLoc.reset()
         balLoc.reset()
         fairyLoc.reset()
         waypoints.clear()
@@ -476,6 +499,7 @@ class MiningFeatures {
                 templeLoc.drawOnMap(50, Color.GREEN.rgb)
                 denLoc.drawOnMap(50, Color.YELLOW.rgb)
                 minesLoc.drawOnMap(50, Color.BLUE.rgb)
+                kingLoc.drawOnMap(50, Color.ORANGE.rgb)
                 balLoc.drawOnMap(50, Color.RED.rgb)
                 fairyLoc.drawOnMap(25, Color.PINK.rgb)
             }
@@ -600,6 +624,7 @@ class MiningFeatures {
         var templeLoc = LocationObject()
         var denLoc = LocationObject()
         var minesLoc = LocationObject()
+        var kingLoc = LocationObject()
         var balLoc = LocationObject()
         var fairyLoc = LocationObject()
         var lastTPLoc: BlockPos? = null


### PR DESCRIPTION
The King is an equally important area to have as a waypoint and marked on the map. Unfortunately, Skyblock does not have a custom location for it like other areas in the Crystal Hollows.

To counteract this, besides setting it manually, I have added a check for messaging starting with "[NPC] King Yolkar" to set the location (and a config to toggle this behavior, if you only want to add King Yolkar manually).