### PR TITLE
Update King Map Size

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -501,7 +501,7 @@ class MiningFeatures {
                 templeLoc.drawOnMap(50, Color.GREEN.rgb)
                 denLoc.drawOnMap(50, Color.YELLOW.rgb)
                 minesLoc.drawOnMap(50, Color.BLUE.rgb)
-                kingLoc.drawOnMap(50, Color.ORANGE.rgb)
+                kingLoc.drawOnMap(25, Color.ORANGE.rgb)
                 balLoc.drawOnMap(50, Color.RED.rgb)
                 fairyLoc.drawOnMap(25, Color.PINK.rgb)
             }


### PR DESCRIPTION
Update King Map Size to be smaller. The area does not need to be as large as traditional crystal areas.

Woke up and realized I forgot to change that yesterday. 