### PR TITLE
Fix alignment task solver

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/AlignmentTaskSolver.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/AlignmentTaskSolver.kt
@@ -63,7 +63,7 @@ object AlignmentTaskSolver {
     @SubscribeEvent
     fun onTick(event: TickEvent.ClientTickEvent) {
         if (mc.thePlayer == null || mc.theWorld == null || event.phase != TickEvent.Phase.START) return
-        if (!Skytils.config.alignmentTerminalSolver || !Utils.inDungeons || Utils.equalsOneOf(
+        if (!Skytils.config.alignmentTerminalSolver || !Utils.inDungeons || !Utils.equalsOneOf(
                 DungeonFeatures.dungeonFloor,
                 "F7", "M7"
             ) || (!SuperSecretSettings.azooPuzzoo && (DungeonTimer.phase2ClearTime == -1L || DungeonTimer.phase3ClearTime != -1L))


### PR DESCRIPTION
Definitely didn't take me about an hour to figure out why it wasn't working.
Bug was introduced in this commit: 37a0c5034987707a58a825d47ea62a4c3f304075

The problem was just a missing negation. Currently, if the player is on F7 or M7, the method returns instead of not returning like it's supposed to.