### PR TITLE
Feature/container sell value

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/Skytils.kt
+++ b/src/main/kotlin/skytils/skytilsmod/Skytils.kt
@@ -206,6 +206,7 @@ class Skytils {
             ArmorColor(),
             AuctionData(),
             AuctionPriceOverlay(),
+            ContainerSellValue(),
             BlazeSolver(),
             BloodHelper,
             BossHPDisplays(),

--- a/src/main/kotlin/skytils/skytilsmod/Skytils.kt
+++ b/src/main/kotlin/skytils/skytilsmod/Skytils.kt
@@ -206,7 +206,7 @@ class Skytils {
             ArmorColor(),
             AuctionData(),
             AuctionPriceOverlay(),
-            ContainerSellValue(),
+            ContainerSellValue,
             BlazeSolver(),
             BloodHelper,
             BossHPDisplays(),

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1603,6 +1603,13 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var betterAuctionPriceInput = false
 
     @Property(
+        type = PropertyType.SWITCH, name = "Container Sell Value",
+        description = "Display the lowest BIN prices for the most valuable items in backpacks, ender chest pages, minions, and island chests.",
+        category = "Miscellaneous", subcategory = "Quality of Life"
+    )
+    var containerSellValue = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Comma Damage",
         description = "§b[WIP] §rAdds commas to Skyblock Damage Splashes.",
         category = "Miscellaneous", subcategory = "Quality of Life"
@@ -2563,7 +2570,8 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
             "betterAuctionPriceInput",
             "dungeonChestProfit",
             "showCoinsPerBit",
-            "protectItemBINThreshold"
+            "protectItemBINThreshold",
+            "containerSellValue"
         ).forEach { propertyName ->
             addDependency(propertyName, "fetchLowestBINPrices")
             registerListener(propertyName) { prop: Any ->

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1610,6 +1610,14 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var containerSellValue = false
 
     @Property(
+        type = PropertyType.NUMBER, name = "Max Displayed Items",
+        description = "The maximum amount of items to display in the Container Sell Value GUI.",
+        category = "Miscellaneous", subcategory = "Quality of Life",
+        min = 5, max = 30, increment = 1
+    )
+    var containerSellValueMaxItems = 20
+
+    @Property(
         type = PropertyType.SWITCH, name = "Comma Damage",
         description = "§b[WIP] §rAdds commas to Skyblock Damage Splashes.",
         category = "Miscellaneous", subcategory = "Quality of Life"

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -2635,6 +2635,8 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         addDependency("markDirtyItems", "dupeTracker")
         addDependency("dupeTrackerOverlayColor", "dupeTracker")
 
+        addDependency("containerSellValueMaxItems", "containerSellValue")
+
         registerListener("protectItemBINThreshold") { _: String ->
             TickTask(1) {
                 val numeric = protectItemBINThreshold.replace(Regex("[^0-9]"), "")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
@@ -154,7 +154,7 @@ class ContainerSellValue {
             }
         }
 
-        if(slots.isEmpty()) return
+        if(slots.isEmpty() || distinctItems.isEmpty() || distinctItems.all { it.value.lowestBIN == 0.0 }) return
 
         // Sort the items from most to least valuable and convert them into a readable format
         val textLines = distinctItems.entries.asSequence()

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
@@ -18,6 +18,7 @@
 
 package skytils.skytilsmod.features.impl.misc
 
+import gg.essential.elementa.utils.LineUtils.drawLine
 import gg.essential.universal.UGraphics
 import gg.essential.universal.UMatrixStack
 import gg.essential.universal.UResolution
@@ -183,22 +184,22 @@ object ContainerSellValue {
             .also { lines = it.size }
             .take(Skytils.config.containerSellValueMaxItems)
 
-        UMatrixStack().apply {
-            // Translate and scale manually because we're not rendering inside the GuiElement#render() method
-            push()
-            translate(element.actualX, element.actualY, 0f)
-            scale(element.scale, element.scale, 0f)
+        // Translate and scale manually because we're not rendering inside the GuiElement#render() method
+        val stack = UMatrixStack()
+        stack.push()
+        stack.translate(element.actualX, element.actualY, 0f)
+        stack.scale(element.scale, element.scale, 0f)
 
-            textLines.forEachIndexed { i, str -> drawLine(this, i, str) }
-            if(lines > Skytils.config.containerSellValueMaxItems) {
-                drawLine(this, textLines.size, "§7and ${lines - Skytils.config.containerSellValueMaxItems} more...")
-                drawLine(this, textLines.size + 1, "§eTotal Value: §a${ NumberUtil.format(totalContainerValue) }")
-            } else {
-                drawLine(this, textLines.size, "§eTotal Value: §a${ NumberUtil.format(totalContainerValue) }")
-            }
+        textLines.forEachIndexed { i, str -> drawLine(stack, i, str) }
+        if(lines > Skytils.config.containerSellValueMaxItems) {
+            drawLine(stack, textLines.size, "§7and ${lines - Skytils.config.containerSellValueMaxItems} more...")
+            drawLine(stack, textLines.size + 1, "§eTotal Value: §a${ NumberUtil.format(totalContainerValue) }")
+        } else {
+            drawLine(stack, textLines.size, "§eTotal Value: §a${ NumberUtil.format(totalContainerValue) }")
+        }
 
-            pop()
-        }.applyToGlobalState()
+        stack.pop()
+        stack.applyToGlobalState()
     }
 
     private fun drawLine(matrixStack: UMatrixStack, index: Int, str: String) {

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
@@ -1,0 +1,174 @@
+/*
+ * Skytils - Hypixel Skyblock Quality of Life Mod
+ * Copyright (C) 2022 Skytils
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package skytils.skytilsmod.features.impl.misc
+
+import gg.essential.universal.UResolution
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.inventory.ContainerChest
+import net.minecraft.inventory.Slot
+import net.minecraft.item.ItemStack
+import net.minecraftforge.client.event.GuiScreenEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import skytils.skytilsmod.Skytils
+import skytils.skytilsmod.Skytils.Companion.mc
+import skytils.skytilsmod.core.structure.FloatPair
+import skytils.skytilsmod.core.structure.GuiElement
+import skytils.skytilsmod.features.impl.handlers.AuctionData
+import skytils.skytilsmod.utils.*
+import skytils.skytilsmod.utils.Utils.inDungeons
+import skytils.skytilsmod.utils.graphics.ScreenRenderer
+import skytils.skytilsmod.utils.graphics.SmartFontRenderer
+import skytils.skytilsmod.utils.graphics.colors.CommonColors
+import kotlin.math.roundToInt
+
+class ContainerSellValue {
+
+    private data class DisplayItem(var amount: Int, val itemStack: ItemStack) {
+        val lowestBIN: Double?
+            get() = AuctionData.lowestBINs[AuctionData.getIdentifier(itemStack)]?.times(amount) ?:
+            ItemFeatures.sellPrices[AuctionData.getIdentifier(itemStack)]?.times(amount)
+        val displayName: String = itemStack.displayName
+
+        fun shouldDisplay(): Boolean = this.lowestBIN != null
+
+        constructor(slot: Slot) : this(slot.stack.stackSize, slot.stack)
+    }
+
+    class SellValueDisplay : GuiElement("Container Sell Value", FloatPair(0.258f, 0.283f)) {
+
+        override fun render() {
+            // Rendering is handled in the BackgroundDrawnEvent to give the text proper lighting
+        }
+
+        override fun demoRender() {
+            val rightAlign = actualX < UResolution.scaledWidth / 2f
+            val alignment = if(rightAlign) SmartFontRenderer.TextAlignment.RIGHT_LEFT
+            else SmartFontRenderer.TextAlignment.LEFT_RIGHT
+            val xPos = if(rightAlign) actualWidth else 0f
+
+            listOf(
+                "§cDctr's Space Helmet§8 - §a900M",
+                "§fDirt §7x64 §8 - §a1k",
+                "§eTotal Value: §a900M"
+            ).forEachIndexed { i, str ->
+                fr.drawString(
+                    str, xPos, (i * fr.FONT_HEIGHT).toFloat(),
+                    CommonColors.WHITE, alignment, SmartFontRenderer.TextShadow.NORMAL
+                )
+            }
+        }
+
+        override val toggled: Boolean = Skytils.config.containerSellValue
+        override val height: Int = fr.FONT_HEIGHT * 20
+        override val width: Int = fr.getStringWidth("Dctr's Space Helmet - 900M")
+
+        init {
+            Skytils.guiManager.registerElement(this)
+        }
+    }
+
+    companion object {
+        val element = SellValueDisplay()
+        // The max amount of BIN prices to show in the list. If there are more items, the list will be truncated to this size.
+        const val MAX_DISPLAYED_ITEMS = 20
+
+        /**
+         * Check if the overlay should be rendered in a container based on its name.
+         * Island chests, backpacks, ender chest pages, and minions are included.
+         */
+        private fun isValidContainer(chestName: String): Boolean {
+            return (!inDungeons && (chestName == "Chest" || chestName == "Large Chest"))
+                    || chestName.contains("Backpack")
+                    || chestName.startsWith("Ender Chest (")
+                    || (chestName.contains("Minion") && SBInfo.mode == SkyblockIsland.PrivateIsland.mode)
+        }
+    }
+
+    /**
+     * Renders the sell value overlay when in a valid GUI.
+     *
+     * Note: It is important that Minecraft Forge's `BackgroundDrawnEvent` is used instead of Skytils's
+     * GuiContainerEvent.BackgroundDrawnEvent because Skytils's event is called before the overlay rectangle is drawn,
+     * causing the text to be dimmed.
+     */
+    @SubscribeEvent
+    fun onBackgroundDrawn(event: GuiScreenEvent.BackgroundDrawnEvent) {
+        val gui = mc.currentScreen
+        val container = if(mc.currentScreen is GuiChest) mc.thePlayer.openContainer as ContainerChest else return
+        val chestName = container.lowerChestInventory.name
+
+        if(!Skytils.config.containerSellValue || gui !is GuiChest || !isValidContainer(chestName)) return
+
+        val rightAlign = element.actualX < UResolution.scaledWidth / 2f
+        val alignment = if(rightAlign) SmartFontRenderer.TextAlignment.RIGHT_LEFT
+        else SmartFontRenderer.TextAlignment.LEFT_RIGHT
+        val xPos = if(rightAlign) element.actualWidth else 0f
+        val isMinion = chestName.contains("Minion")
+
+        // Map all of the items in the chest to their lowest BIN prices
+        val items = container.inventorySlots.filter {
+            it.hasStack && it.inventory != mc.thePlayer.inventory
+                    && (!isMinion || it.slotNumber % 9 != 1) // Ignore minion upgrades and fuels
+        }.map { DisplayItem(it) }.filter { it.shouldDisplay() }
+
+        // Combine items with the same ID to save space in the GUI
+        val distinctItems = mutableMapOf<String, DisplayItem>()
+        items.forEach {
+            if(distinctItems.containsKey(it.displayName)) {
+                distinctItems[it.displayName]!!.apply { amount += it.amount }
+            } else {
+                distinctItems[it.displayName] = it
+            }
+        }
+
+        if(items.isEmpty()) return
+
+        // Sort the items from most to least valuable and convert them into a readable format
+        val textLines = distinctItems.entries
+            .sortedByDescending { (_, displayItem) -> displayItem.lowestBIN }
+            .map { (itemName, displayItem) ->
+            "${itemName}${
+                (" §7x${displayItem.amount}").toStringIfTrue(displayItem.amount > 1)
+            }§8 - §a${NumberUtil.format(displayItem.lowestBIN!!.roundToInt())}"
+        }.take(MAX_DISPLAYED_ITEMS).toMutableList()
+
+        if(distinctItems.size > MAX_DISPLAYED_ITEMS) {
+            textLines.add("§7and ${distinctItems.size - MAX_DISPLAYED_ITEMS} more...")
+        }
+        textLines.add("§eTotal Value: §a${
+            NumberUtil.format(distinctItems.entries.sumOf { it.value.lowestBIN ?: 0.0 })
+        }")
+
+        // Translate and scale manually because we're not rendering inside the GuiElement#render() method
+        GlStateManager.pushMatrix()
+        GlStateManager.translate(element.actualX, element.actualY, 0f)
+        GlStateManager.scale(element.scale, element.scale, 0f)
+
+        textLines.forEachIndexed { i, str ->
+            ScreenRenderer.fontRenderer.drawString(
+                str,
+                xPos, (i * ScreenRenderer.fontRenderer.FONT_HEIGHT).toFloat(),
+                CommonColors.WHITE, alignment, SmartFontRenderer.TextShadow.NORMAL
+            )
+        }
+
+        GlStateManager.popMatrix()
+    }
+}

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
@@ -77,10 +77,10 @@ object ContainerSellValue {
             get() = element.actualX > (UResolution.scaledWidth * 0.75f) ||
                     (element.actualX < UResolution.scaledWidth / 2f && element.actualX > UResolution.scaledWidth / 4f)
         internal val textPosX: Float
-            get() = if(rightAlign) actualWidth else 0f
+            get() = if (rightAlign) actualWidth else 0f
         internal val alignment: SmartFontRenderer.TextAlignment
-            get() = if(rightAlign) SmartFontRenderer.TextAlignment.RIGHT_LEFT
-                    else SmartFontRenderer.TextAlignment.LEFT_RIGHT
+            get() = if (rightAlign) SmartFontRenderer.TextAlignment.RIGHT_LEFT
+            else SmartFontRenderer.TextAlignment.LEFT_RIGHT
 
         override fun render() {
             // Rendering is handled in the BackgroundDrawnEvent to give the text proper lighting
@@ -126,14 +126,15 @@ object ContainerSellValue {
     private val ItemStack.prettyDisplayName: String
         get() {
             val extraAttr = ItemUtil.getExtraAttributes(this) ?: return this.displayName
-            if(ItemUtil.getSkyBlockItemID(extraAttr) == "ENCHANTED_BOOK" && extraAttr.hasKey("enchantments")) {
+            if (ItemUtil.getSkyBlockItemID(extraAttr) == "ENCHANTED_BOOK" && extraAttr.hasKey("enchantments")) {
                 val enchants = extraAttr.getCompoundTag("enchantments")
-                if(enchants.keySet.size == 1) {
+                if (enchants.keySet.size == 1) {
                     return ItemUtil.getItemLore(this).first()
                 }
             }
             return this.displayName
         }
+
     /**
      * Renders the sell value overlay when in a valid GUI.
      *
@@ -144,11 +145,11 @@ object ContainerSellValue {
     @SubscribeEvent
     fun onBackgroundDrawn(event: GuiScreenEvent.BackgroundDrawnEvent) {
         val gui = mc.currentScreen
-        val container = if(mc.currentScreen is GuiChest) mc.thePlayer.openContainer as ContainerChest else return
+        val container = if (mc.currentScreen is GuiChest) mc.thePlayer.openContainer as ContainerChest else return
         val chestName = container.lowerChestInventory.name
         val isMinion = chestName.contains(" Minion ")
 
-        if(!Skytils.config.containerSellValue || gui !is GuiChest || !shouldRenderOverlay(chestName)) return
+        if (!Skytils.config.containerSellValue || gui !is GuiChest || !shouldRenderOverlay(chestName)) return
 
         // Map all of the items in the chest to their lowest BIN prices
         val slots = container.inventorySlots.filter {
@@ -168,7 +169,7 @@ object ContainerSellValue {
 
         val totalContainerValue = distinctItems.entries.sumOf { it.value.lowestBIN }
 
-        if(distinctItems.isEmpty() || totalContainerValue == 0.0) return
+        if (distinctItems.isEmpty() || totalContainerValue == 0.0) return
 
         // Sort the items from most to least valuable and convert them into a readable format
         val lines: Int
@@ -191,11 +192,11 @@ object ContainerSellValue {
         stack.scale(element.scale, element.scale, 0f)
 
         textLines.forEachIndexed { i, str -> drawLine(stack, i, str) }
-        if(lines > Skytils.config.containerSellValueMaxItems) {
+        if (lines > Skytils.config.containerSellValueMaxItems) {
             drawLine(stack, textLines.size, "§7and ${lines - Skytils.config.containerSellValueMaxItems} more...")
-            drawLine(stack, textLines.size + 1, "§eTotal Value: §a${ NumberUtil.format(totalContainerValue) }")
+            drawLine(stack, textLines.size + 1, "§eTotal Value: §a${NumberUtil.format(totalContainerValue)}")
         } else {
-            drawLine(stack, textLines.size, "§eTotal Value: §a${ NumberUtil.format(totalContainerValue) }")
+            drawLine(stack, textLines.size, "§eTotal Value: §a${NumberUtil.format(totalContainerValue)}")
         }
 
         stack.pop()
@@ -203,9 +204,11 @@ object ContainerSellValue {
     }
 
     private fun drawLine(matrixStack: UMatrixStack, index: Int, str: String) {
-        UGraphics.drawString(matrixStack, str,
-            if(element.rightAlign) element.textPosX - UGraphics.getStringWidth(str) else element.textPosX,
+        UGraphics.drawString(
+            matrixStack, str,
+            if (element.rightAlign) element.textPosX - UGraphics.getStringWidth(str) else element.textPosX,
             (index * ScreenRenderer.fontRenderer.FONT_HEIGHT).toFloat(),
-            Color.WHITE.rgb, true)
+            Color.WHITE.rgb, true
+        )
     }
 }

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/misc/ContainerSellValue.kt
@@ -61,7 +61,8 @@ class ContainerSellValue {
         }
 
         override fun demoRender() {
-            val rightAlign = actualX < UResolution.scaledWidth / 2f
+            val rightAlign = actualX > (UResolution.scaledWidth * 0.75f) ||
+                    (actualX < UResolution.scaledWidth / 2f && actualX > UResolution.scaledWidth / 4f)
             val alignment = if(rightAlign) SmartFontRenderer.TextAlignment.RIGHT_LEFT
             else SmartFontRenderer.TextAlignment.LEFT_RIGHT
             val xPos = if(rightAlign) actualWidth else 0f
@@ -130,7 +131,8 @@ class ContainerSellValue {
 
         if(!Skytils.config.containerSellValue || gui !is GuiChest || !isValidContainer(chestName)) return
 
-        val rightAlign = element.actualX < UResolution.scaledWidth / 2f
+        val rightAlign = element.actualX > (UResolution.scaledWidth * 0.75f) ||
+                (element.actualX < UResolution.scaledWidth / 2f && element.actualX > UResolution.scaledWidth / 4f)
         val alignment = if(rightAlign) SmartFontRenderer.TextAlignment.RIGHT_LEFT
         else SmartFontRenderer.TextAlignment.LEFT_RIGHT
         val xPos = if(rightAlign) element.actualWidth else 0f


### PR DESCRIPTION
I added an overlay that renders when a chest, ender chest page, backpack, or minion is open and shows the container's 20 most valuable items along with the combined value of all items in the container. It can be moved and scaled just like a regular `GuiElement`, but it is rendered after the container background is drawn to prevent the text from being dimmed (similar to the `ChestProfit` element). When the overlay is rendered over a minion GUI, minion upgrades and fuels aren't included in the value.

* Should I add config options to control the maximum amount of items to display?
* Should I include things like enchantments and HPBs in item prices?
* Should enchanted books be grouped by enchantments or by item name? Currently all items are grouped by item name, and enchanted books are only displayed as "Enchanted Book" instead of something like "Soul Eater I"
* Let me know if you want any formatting changes

Here's an example of this overlay being used while inside a minion GUI:
![image](https://user-images.githubusercontent.com/31071265/159999927-0ad341a9-53d2-4048-9460-8f24d74a8731.png)

Example of the truncation:
![image](https://user-images.githubusercontent.com/31071265/160008085-13d3caa2-51c8-4a5d-98bf-af8c347d2bb0.png)