### PR TITLE
changed/added smaller features

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -18,8 +18,8 @@
 package skytils.skytilsmod.core
 
 import gg.essential.api.EssentialAPI
-import gg.essential.universal.UDesktop
 import gg.essential.elementa.utils.withAlpha
+import gg.essential.universal.UDesktop
 import gg.essential.vigilance.Vigilant
 import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.data.Property
@@ -1126,7 +1126,7 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "Mining", subcategory = "Quality of Life"
     )
     var skymallReminder = false
-    
+
     @Property(
         type = PropertyType.SWITCH, name = "Fetchur Solver",
         description = "Tells you what item Fetchur wants.",

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -2600,7 +2600,6 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         addDependency("changeToSameColorMode", "changeAllSameColorTerminalSolver")
         addDependency("lividFinderType", "findCorrectLivid")
 
-
         listOf(
             "showGriffinCountdown",
             "particleBurrows",

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -1128,13 +1128,6 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var skymallReminder = false
 
     @Property(
-        type = PropertyType.SWITCH, name = "§b[WIP] §rSearch Box",
-        description = "§b[WIP] §rDisplays a search box in chest guis.",
-        category = "Miscellaneous", subcategory = "Quality of Life"
-    )
-    var searchBox = false
-
-    @Property(
         type = PropertyType.SWITCH, name = "Fetchur Solver",
         description = "Tells you what item Fetchur wants.",
         category = "Mining", subcategory = "Solvers"

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -18,8 +18,8 @@
 package skytils.skytilsmod.core
 
 import gg.essential.api.EssentialAPI
-import gg.essential.elementa.utils.withAlpha
 import gg.essential.universal.UDesktop
+import gg.essential.elementa.utils.withAlpha
 import gg.essential.vigilance.Vigilant
 import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.data.Property
@@ -113,13 +113,6 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var overrideReparty = true
 
     @Property(
-        type = PropertyType.SWITCH, name = "§b[WIP] §rParty Finder Stats",
-        description = "Displays Stats about a Player who joined.",
-        category = "Dungeons", subcategory = "Party Finder"
-    )
-    var partyFinderStats = false
-
-    @Property(
         type = PropertyType.SWITCH, name = "Coop Add Confirmation",
         description = "Requires you to run the /coopadd command twice to add a member.",
         category = "General", subcategory = "Hypixel"
@@ -197,6 +190,13 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "Dungeons", subcategory = "Miscellaneous"
     )
     var deathCounter = false
+
+    @Property(
+        type = PropertyType.SWITCH, name = "§b[WIP] §rParty Finder Stats",
+        description = "Displays Stats about a Player who joined.",
+        category = "Dungeons", subcategory = "Party Finder"
+    )
+    var partyFinderStats = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Dungeon Chest Profit",
@@ -290,11 +290,12 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var sendMessageOn270Score = false
 
     @Property(
-        type = PropertyType.SWITCH, name = "Send message on 300 score",
-        description = "Send message on 300 score.",
-        category = "Dungeons", subcategory = "Score Calculation"
+        type = PropertyType.PARAGRAPH, name = "Message for 270 score",
+        description = "Customize the message sent on hitting 270 score.",
+        category = "Dungeons", subcategory = "Score Calculation",
+        placeholder = "Skytils > 270 score"
     )
-    var sendMessageOn300Score = false
+    var message270Score = ""
 
     @Property(
         type = PropertyType.SWITCH, name = "Create Title on 270 score",
@@ -304,19 +305,19 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var createTitleOn270Score = false
 
     @Property(
-        type = PropertyType.SWITCH, name = "Create Title on 300 score",
-        description = "Create title on 300 score.",
-        category = "Dungeons", subcategory = "Score Calculation"
+        type = PropertyType.PARAGRAPH, name = "270 Title Message",
+        description = "Customize the message that will be sent when the score reaches 270.",
+        category = "Dungeons", subcategory = "Score Calculation",
+        placeholder = "270"
     )
-    var createTitleOn300Score = false
+    var messageTitle270Score = ""
 
     @Property(
-        type = PropertyType.PARAGRAPH, name = "Message for 270 score",
-        description = "Customize the message sent on hitting 270 score.",
-        category = "Dungeons", subcategory = "Score Calculation",
-        placeholder = "Skytils > 270 score"
+        type = PropertyType.SWITCH, name = "Send message on 300 score",
+        description = "Send message on 300 score.",
+        category = "Dungeons", subcategory = "Score Calculation"
     )
-    var message270Score = ""
+    var sendMessageOn300Score = false
 
     @Property(
         type = PropertyType.PARAGRAPH, name = "Message for 300 score",
@@ -325,6 +326,22 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         placeholder = "Skytils > 300 score"
     )
     var message300Score = ""
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Create Title on 300 score",
+        description = "Create title on 300 score.",
+        category = "Dungeons", subcategory = "Score Calculation"
+    )
+    var createTitleOn300Score = false
+
+    @Property(
+        type = PropertyType.PARAGRAPH, name = "300 Title Message",
+        description = "Customize the message that will be sent when the score reaches 300.",
+        category = "Dungeons", subcategory = "Score Calculation",
+        placeholder = "300"
+    )
+    var messageTitle300Score = ""
+
 
     @Property(
         type = PropertyType.SWITCH, name = "Blood Camp Helper",
@@ -1109,6 +1126,13 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "Mining", subcategory = "Quality of Life"
     )
     var skymallReminder = false
+
+    @Property(
+        type = PropertyType.SWITCH, name = "§b[WIP] §rSearch Box",
+        description = "§b[WIP] §rDisplays a search box in chest guis.",
+        category = "Miscellaneous", subcategory = "Quality of Life"
+    )
+    var searchBox = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Fetchur Solver",
@@ -2567,6 +2591,13 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     )
     var compactHider = 0
 
+    @Property(
+        type = PropertyType.SWITCH, name = "Rabbit Hat",
+        description = "Reminds you to equip a Rabbit Hat at the end of a F7 or M7 run.",
+        category = "Notifications", subcategory = "Dungeons"
+    )
+    var rabbitHat = false
+
     init {
         addDependency("showEtherwarpTeleportPosColor", "showEtherwarpTeleportPos")
 
@@ -2586,6 +2617,12 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
             }
         }
 
+        addDependency("message270Score","sendMessageOn270Score")
+        addDependency("messageTitle270Score","createTitleOn270Score")
+
+        addDependency("message300Score","sendMessageOn300Score")
+        addDependency("messageTitle300Score","createTitleOn300Score")
+
         addDependency("bloodHelperColor", "bloodHelper")
 
         addDependency("showNextBlaze", "blazeSolver")
@@ -2599,6 +2636,7 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         addDependency("clickInOrderThird", "clickInOrderTerminalSolver")
         addDependency("changeToSameColorMode", "changeAllSameColorTerminalSolver")
         addDependency("lividFinderType", "findCorrectLivid")
+
 
         listOf(
             "showGriffinCountdown",

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -111,7 +111,7 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "General", subcategory = "Reparty"
     )
     var overrideReparty = true
-    
+
     @Property(
         type = PropertyType.SWITCH, name = "§b[WIP] §rParty Finder Stats",
         description = "Displays Stats about a Player who joined.",

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -199,13 +199,6 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var deathCounter = false
 
     @Property(
-        type = PropertyType.SWITCH, name = "Rabbit Hat",
-        description = "Reminds you to equip a Rabbit Hat at the end of a F7 or M7 run.",
-        category = "Dungeons", subcategory = "Miscellaneous"
-    )
-    var rabbitHat = false
-
-    @Property(
         type = PropertyType.SWITCH, name = "Dungeon Chest Profit",
         description = "Shows the estimated profit for items from chests in dungeons.",
         category = "Dungeons", subcategory = "Miscellaneous"

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -18,8 +18,8 @@
 package skytils.skytilsmod.core
 
 import gg.essential.api.EssentialAPI
-import gg.essential.universal.UDesktop
 import gg.essential.elementa.utils.withAlpha
+import gg.essential.universal.UDesktop
 import gg.essential.vigilance.Vigilant
 import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.data.Property

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -792,19 +792,19 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
     var middleClickTerminals = true
 
     @Property(
+        type = PropertyType.SWITCH, name = "Change All to Same Color Solver",
+        description = "Shows the best path of clicks for the Change All to Same Color Terminal.",
+        category = "Dungeons", subcategory = "Terminal Solvers"
+    )
+    var changeAllSameColorTerminalSolver = false
+
+    @Property(
         type = PropertyType.SELECTOR, name = "Change All to Same Color Solver Mode",
         description = "Changes the display mode of the solver.",
         category = "Dungeons", subcategory = "Terminal Solvers",
         options = ["Normal", "Left/Right", "Monkey"]
     )
     var changeToSameColorMode = 0
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Change All to Same Color Solver",
-        description = "Shows the best path of clicks for the Change All to Same Color Terminal.",
-        category = "Dungeons", subcategory = "Terminal Solvers"
-    )
-    var changeAllSameColorTerminalSolver = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Click in Order Solver",
@@ -1126,7 +1126,7 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "Mining", subcategory = "Quality of Life"
     )
     var skymallReminder = false
-
+    
     @Property(
         type = PropertyType.SWITCH, name = "Fetchur Solver",
         description = "Tells you what item Fetchur wants.",

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -18,8 +18,8 @@
 package skytils.skytilsmod.core
 
 import gg.essential.api.EssentialAPI
-import gg.essential.elementa.utils.withAlpha
 import gg.essential.universal.UDesktop
+import gg.essential.elementa.utils.withAlpha
 import gg.essential.vigilance.Vigilant
 import gg.essential.vigilance.data.Category
 import gg.essential.vigilance.data.Property
@@ -111,7 +111,7 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "General", subcategory = "Reparty"
     )
     var overrideReparty = true
-
+    
     @Property(
         type = PropertyType.SWITCH, name = "§b[WIP] §rParty Finder Stats",
         description = "Displays Stats about a Player who joined.",
@@ -190,6 +190,20 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "Dungeons", subcategory = "Miscellaneous"
     )
     var dungeonDeathCounter = false
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Death Counter HUD",
+        description = "Displays the amount of deaths on your HUD.",
+        category = "Dungeons", subcategory = "Miscellaneous"
+    )
+    var deathCounter = false
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Rabbit Hat",
+        description = "Reminds you to equip a Rabbit Hat at the end of a F7 or M7 run.",
+        category = "Dungeons", subcategory = "Miscellaneous"
+    )
+    var rabbitHat = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Dungeon Chest Profit",
@@ -766,6 +780,14 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         category = "Dungeons", subcategory = "Terminal Solvers"
     )
     var middleClickTerminals = true
+
+    @Property(
+        type = PropertyType.SELECTOR, name = "Change All to Same Color Solver Mode",
+        description = "Changes the display mode of the solver.",
+        category = "Dungeons", subcategory = "Terminal Solvers",
+        options = ["Normal", "Left/Right", "Monkey"]
+    )
+    var changeToSameColorMode = 0
 
     @Property(
         type = PropertyType.SWITCH, name = "Change All to Same Color Solver",
@@ -2582,7 +2604,9 @@ object Config : Vigilant(File("./config/skytils/config.toml"), "Skytils", sortin
         addDependency("clickInOrderFirst", "clickInOrderTerminalSolver")
         addDependency("clickInOrderSecond", "clickInOrderTerminalSolver")
         addDependency("clickInOrderThird", "clickInOrderTerminalSolver")
+        addDependency("changeToSameColorMode", "changeAllSameColorTerminalSolver")
         addDependency("lividFinderType", "findCorrectLivid")
+
 
         listOf(
             "showGriffinCountdown",

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
@@ -23,6 +23,7 @@ import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import skytils.skytilsmod.Skytils
+import skytils.skytilsmod.core.GuiManager
 import skytils.skytilsmod.core.TickTask
 import skytils.skytilsmod.core.structure.FloatPair
 import skytils.skytilsmod.core.structure.GuiElement
@@ -62,6 +63,9 @@ class DungeonTimer {
                 )
             }
             message == "§r§c[BOSS] The Watcher§r§f: You have proven yourself. You may pass.§r" -> {
+                if(Skytils.config.rabbitHat) {
+                    GuiManager.createTitle("§c§lRABBIT HAT", 20)
+                }
                 bloodClearTime = System.currentTimeMillis()
                 if (Skytils.config.dungeonTimer) UChat.chat(
                     "§bWatcher took ${diff(bloodClearTime, bloodOpenTime)} seconds to clear."

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
@@ -23,7 +23,6 @@ import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import skytils.skytilsmod.Skytils
-import skytils.skytilsmod.core.GuiManager
 import skytils.skytilsmod.core.TickTask
 import skytils.skytilsmod.core.structure.FloatPair
 import skytils.skytilsmod.core.structure.GuiElement

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
@@ -23,6 +23,7 @@ import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.EventPriority
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import skytils.skytilsmod.Skytils
+import skytils.skytilsmod.core.GuiManager
 import skytils.skytilsmod.core.TickTask
 import skytils.skytilsmod.core.structure.FloatPair
 import skytils.skytilsmod.core.structure.GuiElement
@@ -62,6 +63,9 @@ class DungeonTimer {
                 )
             }
             message == "§r§c[BOSS] The Watcher§r§f: You have proven yourself. You may pass.§r" -> {
+                if(Skytils.config.rabbitHat && Utils.equalsOneOf(DungeonFeatures.dungeonFloor, "F7", "M7")) {
+                    GuiManager.createTitle("§c§lRABBIT HAT", 20)
+                }
                 bloodClearTime = System.currentTimeMillis()
                 if (Skytils.config.dungeonTimer) UChat.chat(
                     "§bWatcher took ${diff(bloodClearTime, bloodOpenTime)} seconds to clear."

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
@@ -63,9 +63,6 @@ class DungeonTimer {
                 )
             }
             message == "§r§c[BOSS] The Watcher§r§f: You have proven yourself. You may pass.§r" -> {
-                if(Skytils.config.rabbitHat) {
-                    GuiManager.createTitle("§c§lRABBIT HAT", 20)
-                }
                 bloodClearTime = System.currentTimeMillis()
                 if (Skytils.config.dungeonTimer) UChat.chat(
                     "§bWatcher took ${diff(bloodClearTime, bloodOpenTime)} seconds to clear."

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -22,7 +22,6 @@ import gg.essential.universal.UChat
 import gg.essential.universal.wrappers.message.UMessage
 import gg.essential.universal.wrappers.message.UTextComponent
 import kotlinx.coroutines.launch
-import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.event.ClientChatReceivedEvent

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -22,7 +22,6 @@ import gg.essential.universal.UChat
 import gg.essential.universal.wrappers.message.UMessage
 import gg.essential.universal.wrappers.message.UTextComponent
 import kotlinx.coroutines.launch
-import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.event.ClientChatReceivedEvent
@@ -174,7 +173,7 @@ object PartyFinderStats {
                     cataData.highestCompletion?.let { highestFloor ->
                         val completionObj = cataData.completions!!
                         component.append(UTextComponent("§aFloor Completions: §7(Hover)\n").setHoverText(buildString {
-                            for (i in 1..highestFloor) {
+                            for (i in 1 .. highestFloor) {
                                 append("§a")
                                 append("Floor $i: ")
                                 append("§6")
@@ -188,7 +187,7 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§aFastest §6S+ §aCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
-                                        for (i in 1..highestFloor) {
+                                        for (i in 1 .. highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")
@@ -207,7 +206,7 @@ object PartyFinderStats {
                         component.append(
                             UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n").setHoverText(
                                 buildString {
-                                    for (i in 1..highestFloor) {
+                                    for (i in 1 .. highestFloor) {
                                         append("§a")
                                         append("Floor $i: ")
                                         append("§6")
@@ -222,7 +221,7 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§l§4MM §cFastest §6S+ §cCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
-                                        for (i in 1..highestFloor) {
+                                        for (i in 1 .. highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -184,7 +184,7 @@ object PartyFinderStats {
 
                         cataData.fastestTimeSPlus?.run {
                             component.append(
-                                UTextComponent("§aFastest §6S+ §aCompletions: §7(Hover)\n").setHoverText(
+                                UTextComponent("§aFastest §6S+ §aCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
                                         for (i in 1 .. highestFloor) {
                                             append("§a")
@@ -203,7 +203,7 @@ object PartyFinderStats {
                     masterCataData?.highestCompletion?.let { highestFloor ->
                         val masterCompletionObj = masterCataData.completions!!
                         component.append(
-                            UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n\n").setHoverText(
+                            UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n").setHoverText(
                                 buildString {
                                     for (i in 1 .. highestFloor) {
                                         append("§a")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -22,6 +22,7 @@ import gg.essential.universal.UChat
 import gg.essential.universal.wrappers.message.UMessage
 import gg.essential.universal.wrappers.message.UTextComponent
 import kotlinx.coroutines.launch
+import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.event.ClientChatReceivedEvent
@@ -156,6 +157,7 @@ object PartyFinderStats {
 
                             remove(null)
                         }
+
                         component.append(
                             UTextComponent("§dImportant Items: §7(Hover)\n\n").setHoverText(
                                 if(items.isEmpty()) {
@@ -172,7 +174,7 @@ object PartyFinderStats {
                     cataData.highestCompletion?.let { highestFloor ->
                         val completionObj = cataData.completions!!
                         component.append(UTextComponent("§aFloor Completions: §7(Hover)\n").setHoverText(buildString {
-                            for (i in 1 .. highestFloor) {
+                            for (i in 1..highestFloor) {
                                 append("§a")
                                 append("Floor $i: ")
                                 append("§6")
@@ -186,7 +188,7 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§aFastest §6S+ §aCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
-                                        for (i in 1 .. highestFloor) {
+                                        for (i in 1..highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")
@@ -205,7 +207,7 @@ object PartyFinderStats {
                         component.append(
                             UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n").setHoverText(
                                 buildString {
-                                    for (i in 1 .. highestFloor) {
+                                    for (i in 1..highestFloor) {
                                         append("§a")
                                         append("Floor $i: ")
                                         append("§6")
@@ -220,7 +222,7 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§l§4MM §cFastest §6S+ §cCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
-                                        for (i in 1 .. highestFloor) {
+                                        for (i in 1..highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -156,7 +156,6 @@ object PartyFinderStats {
 
                             remove(null)
                         }
-
                         component.append(
                             UTextComponent("§dImportant Items: §7(Hover)\n\n").setHoverText(
                                 if(items.isEmpty()) {

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -22,6 +22,7 @@ import gg.essential.universal.UChat
 import gg.essential.universal.wrappers.message.UMessage
 import gg.essential.universal.wrappers.message.UTextComponent
 import kotlinx.coroutines.launch
+import net.minecraft.client.Minecraft
 import net.minecraft.event.ClickEvent
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.client.event.ClientChatReceivedEvent
@@ -37,6 +38,7 @@ import skytils.skytilsmod.utils.*
 import skytils.skytilsmod.utils.NumberUtil.toRoman
 import skytils.skytilsmod.utils.SkillUtils.level
 import java.util.*
+import kotlin.math.floor
 import kotlin.time.Duration
 
 object PartyFinderStats {
@@ -82,7 +84,7 @@ object PartyFinderStats {
 
                     val secrets = playerResponse.achievements.getOrDefault("skyblock_treasure_hunter", 0)
                     val component = UMessage("&2&l-----------------------------\n")
-                        .append("$name §8» §dCata §9${NumberUtil.nf.format(cataLevel)} ")
+                        .append("$name §8» §dCata §9${NumberUtil.nf.format(floor(cataLevel))} ")
                         .append(
                             UTextComponent("§7[Stats]\n\n")
                                 .setHoverText("§7Click to run: /skytilscata $username")
@@ -155,11 +157,16 @@ object PartyFinderStats {
 
                             remove(null)
                         }
+
                         component.append(
                             UTextComponent("§dImportant Items: §7(Hover)\n\n").setHoverText(
-                                items.joinToString(
-                                    "§8, "
-                                )
+                                if(items.isEmpty()) {
+                                    "§c§lNone"
+                                } else {
+                                    items.joinToString(
+                                        "§8, "
+                                    )
+                                }
                             )
                         )
                     } ?: component.append("§cInventory API disabled!\n\n")
@@ -167,9 +174,9 @@ object PartyFinderStats {
                     cataData.highestCompletion?.let { highestFloor ->
                         val completionObj = cataData.completions!!
                         component.append(UTextComponent("§aFloor Completions: §7(Hover)\n").setHoverText(buildString {
-                            for (i in 0 .. highestFloor) {
+                            for (i in 1..highestFloor) {
                                 append("§a")
-                                append(if (i == 0) "Entrance: " else "Floor $i: ")
+                                append("Floor $i: ")
                                 append("§6")
                                 append(if (i in completionObj) completionObj[i] else "§cDNF")
                                 if (i != highestFloor)
@@ -181,9 +188,9 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§aFastest §6S+ §aCompletions: §7(Hover)\n").setHoverText(
                                     buildString {
-                                        for (i in 0 .. highestFloor) {
+                                        for (i in 1..highestFloor) {
                                             append("§a")
-                                            append(if (i == 0) "Entrance: " else "Floor $i: ")
+                                            append("Floor $i: ")
                                             append("§6")
                                             append(this@run[i]?.timeFormat() ?: "§cNo S+ Completion")
                                             if (i != highestFloor)
@@ -198,9 +205,9 @@ object PartyFinderStats {
                     masterCataData?.highestCompletion?.let { highestFloor ->
                         val masterCompletionObj = masterCataData.completions!!
                         component.append(
-                            UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n").setHoverText(
+                            UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n\n").setHoverText(
                                 buildString {
-                                    for (i in 1 .. highestFloor) {
+                                    for (i in 1..highestFloor) {
                                         append("§a")
                                         append("Floor $i: ")
                                         append("§6")
@@ -213,9 +220,9 @@ object PartyFinderStats {
 
                         cataData.fastestTimeSPlus?.run {
                             component.append(
-                                UTextComponent("§l§4MM §cFastest §6S+ §cCompletions: §7(Hover)\n").setHoverText(
+                                UTextComponent("§l§4MM §cFastest §6S+ §cCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
-                                        for (i in 1 .. highestFloor) {
+                                        for (i in 1..highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")
@@ -230,9 +237,9 @@ object PartyFinderStats {
                     }
 
                     component
-                        .append("\n§aTotal Secrets Found: §l§6${NumberUtil.nf.format(secrets)}")
+                        .append("§aTotal Secrets Found: §l§6${NumberUtil.nf.format(secrets)}\n")
                         .append(
-                            "\n§aBlood Mobs Killed: §l§6${
+                            "§aBlood Mobs Killed: §l§6${
                                 NumberUtil.nf.format(
                                     (profileData.stats?.get("kills_watcher_summon_undead") ?: 0) +
                                             (profileData.stats?.get("kills_master_watcher_summon_undead") ?: 0)
@@ -245,7 +252,7 @@ object PartyFinderStats {
                         )
                         .append("&2&l-----------------------------")
                         .chat()
-                } ?: UChat.chat("§c${username} has not entered The Catacombs!")
+                } ?: UChat.chat("§c$username has not entered The Catacombs!")
             } catch (e: Throwable) {
                 UChat.chat("§cCatacombs XP Lookup Failed: ${e.message ?: e::class.simpleName}")
                 e.printStackTrace()

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -172,7 +172,7 @@ object PartyFinderStats {
                     cataData.highestCompletion?.let { highestFloor ->
                         val completionObj = cataData.completions!!
                         component.append(UTextComponent("§aFloor Completions: §7(Hover)\n").setHoverText(buildString {
-                            for (i in 1..highestFloor) {
+                            for (i in 1 .. highestFloor) {
                                 append("§a")
                                 append("Floor $i: ")
                                 append("§6")
@@ -186,7 +186,7 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§aFastest §6S+ §aCompletions: §7(Hover)\n").setHoverText(
                                     buildString {
-                                        for (i in 1..highestFloor) {
+                                        for (i in 1 .. highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")
@@ -205,7 +205,7 @@ object PartyFinderStats {
                         component.append(
                             UTextComponent("§l§4MM §cFloor Completions: §7(Hover)\n\n").setHoverText(
                                 buildString {
-                                    for (i in 1..highestFloor) {
+                                    for (i in 1 .. highestFloor) {
                                         append("§a")
                                         append("Floor $i: ")
                                         append("§6")
@@ -220,7 +220,7 @@ object PartyFinderStats {
                             component.append(
                                 UTextComponent("§l§4MM §cFastest §6S+ §cCompletions: §7(Hover)\n\n").setHoverText(
                                     buildString {
-                                        for (i in 1..highestFloor) {
+                                        for (i in 1 .. highestFloor) {
                                             append("§a")
                                             append("Floor $i: ")
                                             append("§6")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/ScoreCalculation.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/ScoreCalculation.kt
@@ -220,7 +220,7 @@ object ScoreCalculation {
                 if (!hasSaid270 && score >= 270) {
                     hasSaid270 = true
                     if (Skytils.config.createTitleOn270Score) GuiManager.createTitle(
-                        "§c§l270",
+                        "§c§l" + Skytils.config.messageTitle270Score,
                         20
                     )
                     if (Skytils.config.sendMessageOn270Score) Skytils.sendMessageQueue.add("/pc ${Skytils.config.message270Score.ifBlank { "270 score" }}")
@@ -228,7 +228,7 @@ object ScoreCalculation {
                 if (!hasSaid300 && score >= 300) {
                     hasSaid300 = true
                     if (Skytils.config.createTitleOn300Score) GuiManager.createTitle(
-                        "§c§l300",
+                        "§c§l" + Skytils.config.messageTitle300Score,
                         20
                     )
                     if (Skytils.config.sendMessageOn300Score) Skytils.sendMessageQueue.add("/pc ${Skytils.config.message300Score.ifBlank { "300 score" }}")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/ScoreCalculation.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/ScoreCalculation.kt
@@ -220,18 +220,18 @@ object ScoreCalculation {
                 if (!hasSaid270 && score >= 270) {
                     hasSaid270 = true
                     if (Skytils.config.createTitleOn270Score) GuiManager.createTitle(
-                        Skytils.config.message270Score.ifBlank { "270 score" },
+                        "§c§l270",
                         20
                     )
-                    if (Skytils.config.sendMessageOn270Score) Skytils.sendMessageQueue.add("/pc Skytils-SC > ${Skytils.config.message270Score.ifBlank { "270 score" }}")
+                    if (Skytils.config.sendMessageOn270Score) Skytils.sendMessageQueue.add("/pc ${Skytils.config.message270Score.ifBlank { "270 score" }}")
                 }
                 if (!hasSaid300 && score >= 300) {
                     hasSaid300 = true
                     if (Skytils.config.createTitleOn300Score) GuiManager.createTitle(
-                        Skytils.config.message300Score.ifBlank { "300 score" },
+                        "§c§l300",
                         20
                     )
-                    if (Skytils.config.sendMessageOn300Score) Skytils.sendMessageQueue.add("/pc Skytils-SC > ${Skytils.config.message300Score.ifBlank { "300 score" }}")
+                    if (Skytils.config.sendMessageOn300Score) Skytils.sendMessageQueue.add("/pc ${Skytils.config.message300Score.ifBlank { "300 score" }}")
                 }
             }
         }
@@ -467,7 +467,7 @@ object ScoreCalculation {
                 if (!mimicKilled.get()) {
                     mimicKilled.set(true)
                     if (Skytils.config.scoreCalculationAssist) {
-                        Skytils.sendMessageQueue.add("/pc \$SKYTILS-DUNGEON-SCORE-MIMIC$")
+                        Skytils.sendMessageQueue.add("/pc Mimic Killed!")
                     }
                 }
             }
@@ -494,6 +494,46 @@ object ScoreCalculation {
     init {
         ScoreCalculationElement()
         HugeCryptsCounter()
+        DeathCounter()
+    }
+
+    class DeathCounter : GuiElement("Dungeon Deaths Counter", 2f, FloatPair(200, 200)) {
+        override fun render() {
+            if (toggled && Utils.inDungeons && DungeonTimer.dungeonStartTime != -1L) {
+                val sr = UResolution
+                val leftAlign = actualX < sr.scaledWidth / 2f
+                ScreenRenderer.fontRenderer.drawString(
+                    "Deaths: ${deaths.get()}",
+                    if (leftAlign) 0f else width.toFloat(),
+                    0f,
+                    alignment = if (leftAlign) TextAlignment.LEFT_RIGHT else TextAlignment.RIGHT_LEFT,
+                    customColor = if (deaths.get() > 0) CommonColors.RED else CommonColors.LIGHT_GREEN
+                )
+            }
+        }
+
+        override fun demoRender() {
+            val sr = UResolution
+            val leftAlign = actualX < sr.scaledWidth / 2f
+            ScreenRenderer.fontRenderer.drawString(
+                "Deaths: 0",
+                if (leftAlign) 0f else width.toFloat(),
+                0f,
+                alignment = if (leftAlign) TextAlignment.LEFT_RIGHT else TextAlignment.RIGHT_LEFT,
+                customColor = CommonColors.LIGHT_GREEN
+            )
+        }
+
+        override val toggled: Boolean
+            get() = Skytils.config.deathCounter
+        override val height: Int
+            get() = fr.FONT_HEIGHT
+        override val width: Int
+            get() = fr.getStringWidth("Deaths: 0")
+
+        init {
+            Skytils.guiManager.registerElement(this)
+        }
     }
 
     class HugeCryptsCounter : GuiElement("Dungeon Crypts Counter", 2f, FloatPair(200, 200)) {

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/ChangeAllToSameColorSolver.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/ChangeAllToSameColorSolver.kt
@@ -17,6 +17,7 @@
  */
 package skytils.skytilsmod.features.impl.dungeons.solvers.terminals
 
+import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.inventory.ContainerChest
 import net.minecraft.item.EnumDyeColor
@@ -52,12 +53,17 @@ object ChangeAllToSameColorSolver {
         for ((slot, clicks) in mapping) {
             var betterOpt = if (clicks.first > -clicks.second) "${clicks.second}" else "${clicks.first}"
             var color = CommonColors.WHITE
-            if(Skytils.config.changeToSameColorMode == 2){
-                val leftClick = if(Minecraft.getMinecraft().gameSettings.keyBindAttack.keyCode == -100) "L" else "R"
-                val rightClick = if(Minecraft.getMinecraft().gameSettings.keyBindUseItem.keyCode == -99) "R" else "L"
-                val leftOrRight = if(betterOpt.toInt() < 0) { "${betterOpt.toInt() * -1}$rightClick" } else "${betterOpt}$leftClick"
-                betterOpt = leftOrRight
-            } else if(Skytils.config.changeToSameColorMode == 3){
+            if(Skytils.config.changeToSameColorMode == 1){
+                val leftClick = when(Minecraft.getMinecraft().gameSettings.keyBindAttack.keyCode){
+                    -100 -> "L"
+                    else -> "R"
+                }
+                val rightClick = when(Minecraft.getMinecraft().gameSettings.keyBindUseItem.keyCode){
+                    -100 -> "L"
+                    else -> "R"
+                }
+                betterOpt = if(betterOpt.toInt() < 0) { "${betterOpt.toInt() * -1}$rightClick" } else "${betterOpt}$leftClick"
+            } else if(Skytils.config.changeToSameColorMode == 2){
                 betterOpt = clicks.first.toString()
                 when(betterOpt.toInt()) {
                     1 -> color = CommonColors.GREEN

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/ChangeAllToSameColorSolver.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/ChangeAllToSameColorSolver.kt
@@ -17,7 +17,6 @@
  */
 package skytils.skytilsmod.features.impl.dungeons.solvers.terminals
 
-import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.inventory.ContainerChest
 import net.minecraft.item.EnumDyeColor
@@ -28,7 +27,6 @@ import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.Skytils.Companion.mc
 import skytils.skytilsmod.events.impl.GuiContainerEvent
 import skytils.skytilsmod.utils.Utils
-import skytils.skytilsmod.utils.append
 import skytils.skytilsmod.utils.graphics.ScreenRenderer
 import skytils.skytilsmod.utils.graphics.SmartFontRenderer
 import skytils.skytilsmod.utils.graphics.colors.CommonColors

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/ChangeAllToSameColorSolver.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/ChangeAllToSameColorSolver.kt
@@ -17,6 +17,7 @@
  */
 package skytils.skytilsmod.features.impl.dungeons.solvers.terminals
 
+import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.inventory.ContainerChest
 import net.minecraft.item.EnumDyeColor
@@ -27,6 +28,7 @@ import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.Skytils.Companion.mc
 import skytils.skytilsmod.events.impl.GuiContainerEvent
 import skytils.skytilsmod.utils.Utils
+import skytils.skytilsmod.utils.append
 import skytils.skytilsmod.utils.graphics.ScreenRenderer
 import skytils.skytilsmod.utils.graphics.SmartFontRenderer
 import skytils.skytilsmod.utils.graphics.colors.CommonColors
@@ -50,15 +52,30 @@ object ChangeAllToSameColorSolver {
         }
         GlStateManager.translate(0f, 0f, 299f)
         for ((slot, clicks) in mapping) {
-            val betterOpt = if (clicks.first > -clicks.second) clicks.second else clicks.first
+            var betterOpt = if (clicks.first > -clicks.second) "${clicks.second}" else "${clicks.first}"
+            var color = CommonColors.WHITE
+            if(Skytils.config.changeToSameColorMode == 2){
+                val leftClick = if(Minecraft.getMinecraft().gameSettings.keyBindAttack.keyCode == -100) "L" else "R"
+                val rightClick = if(Minecraft.getMinecraft().gameSettings.keyBindUseItem.keyCode == -99) "R" else "L"
+                val leftOrRight = if(betterOpt.toInt() < 0) { "${betterOpt.toInt() * -1}$rightClick" } else "${betterOpt}$leftClick"
+                betterOpt = leftOrRight
+            } else if(Skytils.config.changeToSameColorMode == 3){
+                betterOpt = clicks.first.toString()
+                when(betterOpt.toInt()) {
+                    1 -> color = CommonColors.GREEN
+                    2,3 -> color = CommonColors.YELLOW
+                    4 -> color = CommonColors.RED
+                }
+            }
+
             GlStateManager.disableLighting()
             GlStateManager.disableDepth()
             GlStateManager.disableBlend()
             ScreenRenderer.fontRenderer.drawString(
-                "$betterOpt",
+                betterOpt,
                 slot.xDisplayPosition + 9f,
                 slot.yDisplayPosition + 4f,
-                CommonColors.WHITE,
+                color,
                 SmartFontRenderer.TextAlignment.MIDDLE,
                 SmartFontRenderer.TextShadow.NORMAL
             )

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/trackers/impl/DupeTracker.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/trackers/impl/DupeTracker.kt
@@ -33,6 +33,7 @@ import skytils.skytilsmod.events.impl.MainReceivePacketEvent
 import skytils.skytilsmod.features.impl.trackers.Tracker
 import skytils.skytilsmod.utils.*
 import skytils.skytilsmod.utils.RenderUtil.highlight
+import java.awt.Color
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import kotlin.concurrent.fixedRateTimer

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/trackers/impl/DupeTracker.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/trackers/impl/DupeTracker.kt
@@ -33,7 +33,6 @@ import skytils.skytilsmod.events.impl.MainReceivePacketEvent
 import skytils.skytilsmod.features.impl.trackers.Tracker
 import skytils.skytilsmod.utils.*
 import skytils.skytilsmod.utils.RenderUtil.highlight
-import java.awt.Color
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import kotlin.concurrent.fixedRateTimer


### PR DESCRIPTION
Config:
- Made Party Finder stats inside the Dungeons category(inside the code)
- added 270 and 300 title message config
- changed 270 and 300 to be not inside of each other(so it's 270, 270, 300, 300 instead of 270, 300, 270, 300)
- added change all to same color modes(Normal, Left/Right, Monkey) *can be renamed*
- added dependencies for 270 and 300 stuff and change to same color

Party Finder Stats:
- Floored cata for cleaner message
- added default message when no items
- made it ignore Entrance(cause no one cares)
- made all \n be on the right side
- Removed Misc message part (To make it cleaner)
- removed not needed {}

Score Calculation:
- custom 270 and 300 title message
- shortened the 270 and 300 chat message(no prefix)
- make mimic killed message look cleaner(Mimic Killed! instead of that abomination)

Change All to same color:
- added 3 modes:
- Normal has positive and negative numbers(currently all white)
- left/right has left/right click(currently all white)
- Monkey has Left click only numbers(1 click green:2,3 clicks yellow;4 clicks red)