### PR TITLE
Censor API keys in chat messages from griffin burrows

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/features/impl/events/GriffinBurrows.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/events/GriffinBurrows.kt
@@ -124,9 +124,9 @@ object GriffinBurrows {
                     } else UChat.chat("§aSkytils loaded §2${receivedBurrows.size}§a burrows!")
                 }
             } catch (apiException: HypixelAPIException) {
-                UChat.chat("§cFailed to get burrows with reason: ${apiException.message?.replace(Skytils.config.apiKey, "***")}")
+                UChat.chat("§cFailed to get burrows with reason: ${apiException.message?.replace(Skytils.config.apiKey, "*".repeat(Skytils.config.apiKey.length))}")
             } catch (e: Exception) {
-                UChat.chat("§cSkytils ran into a fatal error whilst fetching burrows, please report this on our Discord. ${e::class.simpleName}: ${e.message?.replace(Skytils.config.apiKey, "***")}")
+                UChat.chat("§cSkytils ran into a fatal error whilst fetching burrows, please report this on our Discord. ${e::class.simpleName}: ${e.message?.replace(Skytils.config.apiKey, "*".repeat(Skytils.config.apiKey.length))}")
                 e.printStackTrace()
             }
         }

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/events/GriffinBurrows.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/events/GriffinBurrows.kt
@@ -124,9 +124,9 @@ object GriffinBurrows {
                     } else UChat.chat("§aSkytils loaded §2${receivedBurrows.size}§a burrows!")
                 }
             } catch (apiException: HypixelAPIException) {
-                UChat.chat("§cFailed to get burrows with reason: ${apiException.message}")
+                UChat.chat("§cFailed to get burrows with reason: ${apiException.message?.replace(Skytils.config.apiKey, "***")}")
             } catch (e: Exception) {
-                UChat.chat("§cSkytils ran into a fatal error whilst fetching burrows, please report this on our Discord. ${e::class.simpleName}: ${e.message}")
+                UChat.chat("§cSkytils ran into a fatal error whilst fetching burrows, please report this on our Discord. ${e::class.simpleName}: ${e.message?.replace(Skytils.config.apiKey, "***")}")
                 e.printStackTrace()
             }
         }


### PR DESCRIPTION
Currently, if API requests fail while fetching griffin burrows, your API key printed into the chat, which isn't ideal for content creators or people sharing their screen.

This PR replaces API keys with asterisks in all error messages. It shouldn't make these error messages any less descriptive so I don't think there is any reason to not merge this.