### PR TITLE
Fix remaining chat messages with uncensored API keys

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/commands/stats/StatCommand.kt
+++ b/src/main/kotlin/skytils/skytilsmod/commands/stats/StatCommand.kt
@@ -60,7 +60,7 @@ abstract class StatCommand(
                 val profile = try {
                     Skytils.hylinAPI.getLatestSkyblockProfileForMemberSync(uuid)
                 } catch (e: HypixelAPIException) {
-                    printMessage("§cUnable to retrieve profile information: ${e.message}")
+                    printMessage("§cUnable to retrieve profile information: ${e.message?.replace(Skytils.config.apiKey, "*".repeat(Skytils.config.apiKey.length))}")
                     return@submit
                 } ?: return@submit
                 displayStats(username, uuid, profile)

--- a/src/main/kotlin/skytils/skytilsmod/commands/stats/impl/CataCommand.kt
+++ b/src/main/kotlin/skytils/skytilsmod/commands/stats/impl/CataCommand.kt
@@ -41,7 +41,7 @@ object CataCommand : StatCommand("skytilscata") {
         val playerResponse = try {
             Skytils.hylinAPI.getPlayerSync(uuid)
         } catch (e: HypixelAPIException) {
-            printMessage("§cFailed to get dungeon stats: ${e.message}")
+            printMessage("§cFailed to get dungeon stats: ${e.message?.replace(Skytils.config.apiKey, "*".repeat(Skytils.config.apiKey.length))}")
             return
         }
 

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/dungeons/PartyFinderStats.kt
@@ -59,7 +59,7 @@ object PartyFinderStats {
                     Skytils.hylinAPI.getLatestSkyblockProfileForMember(uuid).whenComplete { profile ->
                         profile?.run { playerStats(username, uuid, this) }
                     }.catch { e ->
-                        UChat.chat("§cUnable to retrieve profile information: ${e.message}")
+                        UChat.chat("§cUnable to retrieve profile information: ${e.message?.replace(Skytils.config.apiKey, "*".repeat(Skytils.config.apiKey.length))}")
                     }
                 }.catch { e ->
                     UChat.chat("§cFailed to get UUID, reason: ${e.message}")
@@ -251,7 +251,7 @@ object PartyFinderStats {
                 e.printStackTrace()
             }
         }.catch { e ->
-            UChat.chat("§cFailed to get dungeon stats: ${e.message}")
+            UChat.chat("§cFailed to get dungeon stats: ${e.message?.replace(Skytils.config.apiKey, "*".repeat(Skytils.config.apiKey.length))}")
         }
     }
 


### PR DESCRIPTION
Same thing as my previous PR for griffin burrows because the last one wasn't very thorough.

Fixes potentially leaking api keys in chat for:
- Party finder stats
- Stats commands
- /skytilscata command

This should be every possible error message that can leak an api key, I haven't seen any others. Also, wouldn't it be better to just censor them when the exception is thrown [here](https://github.com/Skytils/Hylin/blob/04665adf92fabc9aadb000da01ef20dca3b92a6f/lib/src/main/kotlin/skytils/hylin/request/ConnectionHandler.kt#L67)? (Or maybe add it as an option in the `createHylinAPI` method)