### PR TITLE
Fix waypoint chat message

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -208,7 +208,7 @@ class MiningFeatures {
             "§3Skytils > §eFound coordinates in a chat message, click a button to set a waypoint.\n"
         )
         for (loc in CrystalHollowsMap.Locations.values()) {
-            if (!loc.loc.exists()) continue
+            if (loc.loc.exists()) continue
             message.append(
                 UTextComponent("${loc.displayName} ")
                     .setClick(MCClickEventAction.SUGGEST_COMMAND, "/skytilshollowwaypoint set ${loc.id} $x $y $z")


### PR DESCRIPTION
GitHub web editor on top
Currently the location is only added to the chat message if it already exists, this should be the opposite
see https://discord.com/channels/807302538558308352/843991344707141670/959204957570101259