### PR TITLE
Waypoint categories

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
@@ -17,23 +17,20 @@
  */
 package skytils.skytilsmod.features.impl.handlers
 
-import com.google.gson.JsonArray
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import gg.essential.elementa.utils.withAlpha
 import gg.essential.universal.UGraphics
 import gg.essential.universal.UMatrixStack
+import kotlinx.serialization.*
 import net.minecraft.util.BlockPos
 import net.minecraftforge.client.event.RenderWorldLastEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import skytils.hylin.extension.getString
 import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.utils.*
 import java.awt.Color
 import java.io.File
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
+import java.io.Reader
+import java.io.Writer
 
 class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
 
@@ -51,153 +48,91 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
         }
     }
 
-    override fun read(reader: InputStreamReader) {
-        importFromGenericJsonObject(gson.fromJson(reader, JsonElement::class.java))
-    }
-
-    override fun write(writer: OutputStreamWriter) {
-        val parentObj = JsonObject()
-        val categoriesList = JsonArray()
-
-        categories.forEach { category ->
-            val categoryObj = JsonObject()
-            categoryObj.addProperty("name", category.name ?: "")
-            categoryObj.addProperty("island", category.island.mode)
-            categoryObj.addProperty("isExpanded", category.isExpanded)
-            val waypointsList = JsonArray()
-            category.waypoints.forEach {
-                waypointsList.add(JsonObject().apply {
-                    addProperty("name", it.name)
-                    addProperty("x", it.pos.x)
-                    addProperty("y", it.pos.y)
-                    addProperty("z", it.pos.z)
-                    addProperty("enabled", it.enabled)
-                    addProperty("color", it.color.rgb)
-                    addProperty("addedAt", it.addedAt)
-                })
+    override fun read(reader: Reader) {
+        runCatching {
+            categories.addAll(json.decodeFromString<List<WaypointCategory>>(reader.readText()))
+        }.onFailure { e ->
+            println("Error loading waypoints from PersistentSave:")
+            e.printStackTrace()
+            // Error loading the new Waypoint format. Try loading the old format.
+            val waypointsList = json.decodeFromString<List<Waypoint>>(reader.readText()).toHashSet()
+            waypointsList.groupBy {
+                @Suppress("DEPRECATION")
+                it.island!!
+            }.forEach { (island, waypoints) ->
+                categories.add(
+                    WaypointCategory(
+                        name = null,
+                        waypoints = waypoints.toHashSet(),
+                        isExpanded = true,
+                        island = island
+                    )
+                )
             }
-            categoryObj.add("waypoints", waypointsList)
-            categoriesList.add(categoryObj)
         }
-
-        parentObj.add("categories", categoriesList)
-        gson.toJson(parentObj, writer)
     }
 
-    override fun setDefault(writer: OutputStreamWriter) {
-        gson.toJson(JsonObject(), writer)
+    override fun write(writer: Writer) {
+        writer.write(json.encodeToString(CategoryList(categories.toList())))
+    }
+
+    override fun setDefault(writer: Writer) {
+        writer.write(json.encodeToString(CategoryList(emptyList())))
     }
 
     companion object {
         @JvmField
         val categories = HashSet<WaypointCategory>()
-
-        private val sbeWaypointFormat =
-            Regex("(?:\\/?crystalwaypoint parse )?(?<name>[a-zA-Z\\d]+)@(?<x>[-\\d]+),(?<y>[-\\d]+),(?<z>[-\\d]+)\\\\?n?")
-
-        /**
-         * Imports waypoints from either a [JsonArray] (old format) or a [JsonObject] (new format)
-         * and adds them to the [categories] list.
-         *
-         * @param obj An instance of a [JsonArray] or a [JsonObject]
-         * @return The number of waypoints that were added
-         */
-        fun importFromGenericJsonObject(obj: JsonElement): Int {
-            var count = 0
-            if (obj.isJsonObject) {
-                obj as JsonObject
-                // Newer save format including waypoint categories
-                val categoriesList = obj["categories"].asJsonArray
-                for (category in categoriesList) {
-                    category as JsonObject
-                    categories.add(
-                        WaypointCategory(
-                            category["name"].asString,
-                            category["waypoints"].asJsonArray.map { e ->
-                                count++
-                                (e as JsonObject).asWaypoint()
-                            }.toHashSet(),
-                            category["isExpanded"]?.asBoolean ?: true,
-                            SkyblockIsland.values().find { it.mode == category.getIsland() } ?: continue
-                        )
-                    )
-                }
-            } else if (obj.isJsonArray) {
-                obj as JsonArray
-                // Older save format without waypoint categories
-                for (group in obj.groupBy { it.asJsonObject.getIsland() }) {
-                    categories.add(
-                        WaypointCategory(
-                            name = null,
-                            waypoints = group.value.map { e ->
-                                count++
-                                (e as JsonObject).asWaypoint()
-                            }.toHashSet(),
-                            isExpanded = true,
-                            island = SkyblockIsland.values().find { it.mode == group.key } ?: continue
-                        )
-                    )
-                }
-            } else if (obj.isJsonPrimitive) {
-                // This string might be in the SBE format, let's convert it so people don't complain
-                val str = obj.asString
-                if (str.contains("@")) {
-                    val waypoints = sbeWaypointFormat.findAll(str.trim()).map {
-                        Waypoint(
-                            it.groups["name"]!!.value, BlockPos(
-                                it.groups["x"]!!.value.toInt(),
-                                it.groups["y"]!!.value.toInt(),
-                                it.groups["z"]!!.value.toInt()
-                            ), true, Color.RED, System.currentTimeMillis()
-                        )
-                    }
-                    if (!waypoints.iterator().hasNext()) {
-                        error("invalid JSON type")
-                    }
-                    categories.add(
-                        WaypointCategory(
-                            name = null,
-                            waypoints = waypoints.toHashSet(),
-                            isExpanded = true,
-                            island = SkyblockIsland.values().find { it.mode == SBInfo.mode }
-                                ?: SkyblockIsland.CrystalHollows
-                        ))
-                } else error("invalid JSON type")
-            }
-            return count
-        }
-
-        private fun JsonObject.asWaypoint(): Waypoint {
-            return Waypoint(
-                this["name"].asString,
-                BlockPos(this["x"].asInt, this["y"].asInt, this["z"].asInt),
-                this["enabled"].asBoolean,
-                this["color"]?.let { Color(it.asInt, true) } ?: Color.RED,
-                this["addedAt"]?.asLong ?: System.currentTimeMillis()
-            )
-        }
-
-        private fun JsonObject.getIsland() = this.getString("island")
     }
 }
 
 /**
+ * Represents the top-level structure of the JSON file. At the moment, this only contains a list of [WaypointCategory] objects.
+ */
+@Serializable
+data class CategoryList(
+    val categories: List<WaypointCategory>
+)
+
+/**
  * Represents a collection of waypoints, including a name, island, and a list of [Waypoint] objects.
  */
+@Serializable
 data class WaypointCategory(
     var name: String?,
     val waypoints: HashSet<Waypoint>,
     var isExpanded: Boolean = true,
+    @Serializable(with = SkyblockIslandModeSerializer::class)
     var island: SkyblockIsland
 )
 
-data class Waypoint(
+@Serializable
+data class Waypoint @OptIn(ExperimentalSerializationApi::class) constructor(
     var name: String,
-    var pos: BlockPos,
-    var enabled: Boolean,
-    val color: Color,
-    val addedAt: Long
+    // `pos` is separated into three different fields because we want "x", "y", and "z" fields
+    // instead of a parent object "pos" containing three child fields. This helps keep compatibility with older versions.
+    private var x: Int,
+    private var y: Int,
+    private var z: Int,
+    @EncodeDefault
+    var enabled: Boolean = true,
+    @Serializable(with = IntColorSerializer::class)
+    val color: Color = Color.RED,
+    @EncodeDefault
+    val addedAt: Long = System.currentTimeMillis(),
+    @Deprecated("Should only exist in older data formats which do not have waypoint categories.")
+    @Serializable(with = SkyblockIslandModeSerializer::class)
+    var island: SkyblockIsland? = null
 ) {
+
+    var pos
+        get() = BlockPos(x, y, z)
+        set(value) {
+            x = value.x
+            y = value.y
+            z = value.z
+        }
+
     fun draw(partialTicks: Float, matrixStack: UMatrixStack) {
         val (viewerX, viewerY, viewerZ) = RenderUtil.getViewerPos(partialTicks)
         RenderUtil.drawFilledBoundingBox(

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
@@ -50,12 +50,12 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
 
     override fun read(reader: Reader) {
         runCatching {
-            categories.addAll(json.decodeFromString<List<WaypointCategory>>(reader.readText()))
+            categories.addAll(json.decodeFromString<CategoryList>(reader.readText()).categories)
         }.onFailure { e ->
             println("Error loading waypoints from PersistentSave:")
             e.printStackTrace()
             // Error loading the new Waypoint format. Try loading the old format.
-            val waypointsList = json.decodeFromString<List<Waypoint>>(reader.readText()).toHashSet()
+            val waypointsList = json.decodeFromString<HashSet<Waypoint>>(reader.readText())
             waypointsList.groupBy {
                 @Suppress("DEPRECATION")
                 it.island!!
@@ -73,11 +73,11 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
     }
 
     override fun write(writer: Writer) {
-        writer.write(json.encodeToString(CategoryList(categories.toList())))
+        writer.write(json.encodeToString(CategoryList(categories)))
     }
 
     override fun setDefault(writer: Writer) {
-        writer.write(json.encodeToString(CategoryList(emptyList())))
+        writer.write(json.encodeToString(CategoryList(emptySet())))
     }
 
     companion object {
@@ -91,7 +91,7 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
  */
 @Serializable
 data class CategoryList(
-    val categories: List<WaypointCategory>
+    val categories: Set<WaypointCategory>
 )
 
 /**
@@ -100,9 +100,9 @@ data class CategoryList(
 @Serializable
 data class WaypointCategory(
     var name: String?,
-    val waypoints: HashSet<Waypoint>,
+    val waypoints: Set<Waypoint>,
     var isExpanded: Boolean = true,
-    @Serializable(with = SkyblockIslandModeSerializer::class)
+    @Serializable(with = SkyblockIsland.ModeSerializer::class)
     var island: SkyblockIsland
 )
 
@@ -121,7 +121,7 @@ data class Waypoint @OptIn(ExperimentalSerializationApi::class) constructor(
     @EncodeDefault
     val addedAt: Long = System.currentTimeMillis(),
     @Deprecated("Should only exist in older data formats which do not have waypoint categories.")
-    @Serializable(with = SkyblockIslandModeSerializer::class)
+    @Serializable(with = SkyblockIsland.ModeSerializer::class)
     var island: SkyblockIsland? = null
 ) {
 

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
@@ -25,6 +25,7 @@ import gg.essential.universal.UMatrixStack
 import net.minecraft.util.BlockPos
 import net.minecraftforge.client.event.RenderWorldLastEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import skytils.hylin.extension.getOptionalString
 import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.utils.*
@@ -50,9 +51,8 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
         val arr = gson.fromJson(reader, JsonArray::class.java)
         arr.mapNotNullTo(waypoints) { e ->
             e as JsonObject
-            val category = if(e.has("category")) e["category"].asString else null
             Waypoint(
-                category,
+                e.getOptionalString("category").ifEmpty { null },
                 e["name"].asString,
                 BlockPos(
                     e["x"].asInt,

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/Waypoints.kt
@@ -26,9 +26,9 @@ import gg.essential.universal.UMatrixStack
 import net.minecraft.util.BlockPos
 import net.minecraftforge.client.event.RenderWorldLastEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import skytils.hylin.extension.getString
 import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.core.PersistentSave
-import skytils.skytilsmod.features.impl.mining.MiningFeatures.Companion.waypoints
 import skytils.skytilsmod.utils.*
 import java.awt.Color
 import java.io.File
@@ -115,24 +115,23 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
                                 (e as JsonObject).asWaypoint()
                             }.toHashSet(),
                             category["isExpanded"]?.asBoolean ?: true,
-                            SkyblockIsland.values().find { it.mode == category["island"].asString } ?: continue
+                            SkyblockIsland.values().find { it.mode == category.getIsland() } ?: continue
                         )
                     )
                 }
             } else if (obj.isJsonArray) {
                 obj as JsonArray
                 // Older save format without waypoint categories
-                val groupedByIsland = obj.groupBy { it.asJsonObject["island"].asString }
-                for (group in groupedByIsland) {
+                for (group in obj.groupBy { it.asJsonObject.getIsland() }) {
                     categories.add(
                         WaypointCategory(
-                            null as String?,
-                            group.value.map { e ->
+                            name = null,
+                            waypoints = group.value.map { e ->
                                 count++
                                 (e as JsonObject).asWaypoint()
                             }.toHashSet(),
-                            true,
-                            SkyblockIsland.values().find { it.mode == group.key } ?: continue
+                            isExpanded = true,
+                            island = SkyblockIsland.values().find { it.mode == group.key } ?: continue
                         )
                     )
                 }
@@ -149,9 +148,14 @@ class Waypoints : PersistentSave(File(Skytils.modDir, "waypoints.json")) {
                 this["addedAt"]?.asLong ?: System.currentTimeMillis()
             )
         }
+
+        private fun JsonObject.getIsland() = this.getString("island")
     }
 }
 
+/**
+ * Represents a collection of waypoints, including a name, island, and a list of [Waypoint] objects.
+ */
 data class WaypointCategory(
     var name: String?,
     val waypoints: HashSet<Waypoint>,

--- a/src/main/kotlin/skytils/skytilsmod/gui/CommandAliasesGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/CommandAliasesGui.kt
@@ -30,6 +30,7 @@ import gg.essential.vigilance.utils.onLeftClick
 import net.minecraft.util.ChatAllowedCharacters
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.features.impl.handlers.CommandAliases
+import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import java.awt.Color
 
@@ -74,25 +75,7 @@ class CommandAliasesGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reo
             addNewAlias()
         }
 
-        val tooltipBlock = UIBlock().constrain {
-            x = 5.pixels(); y = basicYConstraint { it.parent.getTop() - it.getHeight() - 6 }; height =
-            ChildBasedSizeConstraint(4f); width = ChildBasedSizeConstraint(4f); color =
-            ConstantColorConstraint(Color(224, 224, 224, 100))
-        }.effect(OutlineEffect(Color(0, 243, 255), 1f)).also { it.hide() }
-            .addChild(UIWrappedText("What are aliases? Aliases are little shortcuts for commands. For example, /slay could be short for /skytilsslayer. Want to give it a try? Click 'Add Alias', enter 'slay' for 'Alias Name' and 'skytilsslayer' as the executed command! Then, run the command /slay Sychic! Aliases will also append any arguments that you supply.").constrain {
-                x = 2.pixels(); y = 0.pixels(); width = 90.percentOfWindow()
-            })
-        UICircle(7f).childOf(window).constrain {
-            x = 9.pixels()
-            y = basicYConstraint { it.parent.getBottom() - it.getHeight() - 2 }
-        }.addChildren(
-            UIText("?", true).constrain { x = CenterConstraint(); y = CenterConstraint() },
-            tooltipBlock
-        ).onMouseEnter {
-            tooltipBlock.unhide()
-        }.onMouseLeave {
-            tooltipBlock.hide()
-        }
+        HelpComponent(window, "What are aliases? Aliases are little shortcuts for commands. For example, /slay could be short for /skytilsslayer. Want to give it a try? Click 'Add Alias', enter 'slay' for 'Alias Name' and 'skytilsslayer' as the executed command! Then, run the command /slay Sychic! Aliases will also append any arguments that you supply.")
 
         for (name in CommandAliases.aliases) {
             addNewAlias(name.key, name.value)

--- a/src/main/kotlin/skytils/skytilsmod/gui/CustomNotificationsGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/CustomNotificationsGui.kt
@@ -30,6 +30,7 @@ import gg.essential.universal.UKeyboard
 import gg.essential.vigilance.utils.onLeftClick
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.features.impl.handlers.CustomNotifications
+import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import java.awt.Color
 
@@ -82,25 +83,7 @@ class CustomNotificationsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2)
             addNewNotification()
         }
 
-        val tooltipBlock = UIBlock().constrain {
-            x = 5.pixels(); y = basicYConstraint { it.parent.getTop() - it.getHeight() - 6 }; height =
-            ChildBasedSizeConstraint(4f); width = ChildBasedSizeConstraint(4f); color =
-            ConstantColorConstraint(Color(224, 224, 224, 100))
-        }.effect(OutlineEffect(Color(0, 243, 255), 1f)).also { it.hide() }
-            .addChild(UIWrappedText("What are custom notifications? Custom Notifications allow you to configure popups for when certain chat messages are entered, using regex.").constrain {
-                x = 2.pixels(); y = 0.pixels(); width = 90.percentOfWindow()
-            })
-        UICircle(7f).childOf(window).constrain {
-            x = 9.pixels()
-            y = basicYConstraint { it.parent.getBottom() - it.getHeight() - 2 }
-        }.addChildren(
-            UIText("?", true).constrain { x = CenterConstraint(); y = CenterConstraint() },
-            tooltipBlock
-        ).onMouseEnter {
-            tooltipBlock.unhide()
-        }.onMouseLeave {
-            tooltipBlock.hide()
-        }
+        HelpComponent(window, "What are custom notifications? Custom Notifications allow you to configure popups for when certain chat messages are entered, using regex.")
 
         for (notif in CustomNotifications.notifications.sortedBy { it.text }) {
             addNewNotification(notif.regex.pattern, notif.text, notif.displayTicks)

--- a/src/main/kotlin/skytils/skytilsmod/gui/EnchantNamesGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/EnchantNamesGui.kt
@@ -30,6 +30,7 @@ import gg.essential.vigilance.utils.onLeftClick
 import net.minecraft.util.ChatAllowedCharacters
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.features.impl.handlers.EnchantNames
+import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import java.awt.Color
 
@@ -74,25 +75,7 @@ class EnchantNamesGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reope
             addNewName()
         }
 
-        val tooltipBlock = UIBlock().constrain {
-            x = 5.pixels(); y = basicYConstraint { it.parent.getTop() - it.getHeight() - 6 }; height =
-            ChildBasedSizeConstraint(4f); width = ChildBasedSizeConstraint(4f); color =
-            ConstantColorConstraint(Color(224, 224, 224, 100))
-        }.effect(OutlineEffect(Color(0, 243, 255), 1f)).also { it.hide() }
-            .addChild(UIWrappedText("What are enchant names? Enchant names simply rename enchants to be anything you want!").constrain {
-                x = 2.pixels(); y = 0.pixels(); width = 90.percentOfWindow()
-            })
-        UICircle(7f).childOf(window).constrain {
-            x = 9.pixels()
-            y = basicYConstraint { it.parent.getBottom() - it.getHeight() - 2 }
-        }.addChildren(
-            UIText("?", true).constrain { x = CenterConstraint(); y = CenterConstraint() },
-            tooltipBlock
-        ).onMouseEnter {
-            tooltipBlock.unhide()
-        }.onMouseLeave {
-            tooltipBlock.hide()
-        }
+        HelpComponent(window, "What are enchant names? Enchant names simply rename enchants to be anything you want!")
 
         for (replacement in EnchantNames.replacements) {
             addNewName(replacement.key, replacement.value)

--- a/src/main/kotlin/skytils/skytilsmod/gui/SuperSecretGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/SuperSecretGui.kt
@@ -30,6 +30,7 @@ import gg.essential.universal.wrappers.UPlayer
 import gg.essential.vigilance.utils.onLeftClick
 import net.minecraft.client.audio.PositionedSoundRecord
 import net.minecraft.util.ResourceLocation
+import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import skytils.skytilsmod.utils.SuperSecretSettings
 import java.awt.Color
@@ -82,25 +83,7 @@ class SuperSecretGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopen
             addNewSetting()
         }
 
-        val tooltipBlock = UIBlock().constrain {
-            x = 5.pixels(); y = basicYConstraint { it.parent.getTop() - it.getHeight() - 6 }; height =
-            ChildBasedSizeConstraint(4f); width = ChildBasedSizeConstraint(4f); color =
-            ConstantColorConstraint(Color(224, 224, 224, 100))
-        }.effect(OutlineEffect(Color(0, 243, 255), 1f)).also { it.hide() }
-            .addChild(UIWrappedText("How did you get here?").constrain {
-                x = 2.pixels(); y = 0.pixels()
-            })
-        UICircle(7f).childOf(window).constrain {
-            x = 9.pixels()
-            y = basicYConstraint { it.parent.getBottom() - it.getHeight() - 2 }
-        }.addChildren(
-            UIText("?", true).constrain { x = CenterConstraint(); y = CenterConstraint() },
-            tooltipBlock
-        ).onMouseEnter {
-            tooltipBlock.unhide()
-        }.onMouseLeave {
-            tooltipBlock.hide()
-        }
+        HelpComponent(window, "How did you get here?")
 
         for (setting in SuperSecretSettings.settings) {
             addNewSetting(setting)

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
@@ -41,6 +41,7 @@ import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import skytils.skytilsmod.utils.SBInfo
 import skytils.skytilsmod.utils.SkyblockIsland
+import skytils.skytilsmod.utils.childContainers
 import skytils.skytilsmod.utils.setState
 import java.awt.Color
 
@@ -181,8 +182,8 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
                 addProperty("island", island.mode)
                 add("waypoints", JsonArray().apply {
                     uiContainer.childContainers.mapNotNull {
-                        val e = entries[it] ?: return@mapNotNull null
-                        if (e.selected.checked)
+                        val e = entries[it]
+                        if (e != null && e.selected.checked)
                             JsonObject().apply {
                                 addProperty("name", e.name.getText())
                                 addProperty("x", e.x.getText().toInt())

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
@@ -42,6 +42,7 @@ import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.features.impl.handlers.Waypoint
 import skytils.skytilsmod.features.impl.handlers.Waypoints
+import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import skytils.skytilsmod.utils.SBInfo
 import skytils.skytilsmod.utils.SkyblockIsland
@@ -119,8 +120,10 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
             exportSelectedWaypoints()
         }
 
+        HelpComponent(window, "This menu is used to share waypoints with other people. To import waypoints from another person, copy the *entire* string of text to your clipboard, and then click 'Import from Clipboard'. To send waypoints to someone else, make sure the ones you want to share are selected and then click 'Export Selected to Clipboard'. Make sure the very long string of text is not cut off by any character limits, or people will not be able to import your waypoints.")
+
         SimpleButton("Select All").childOf(window).constrain {
-            x = 5.pixels()
+            x = SiblingConstraint(5f)
             y = 5.pixels(alignOpposite = true)
         }.onLeftClick {
             if (entries.values.all {

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
@@ -37,6 +37,7 @@ import gg.essential.vigilance.gui.settings.DropDown
 import gg.essential.vigilance.utils.onLeftClick
 import net.minecraft.util.BlockPos
 import org.apache.commons.codec.binary.Base64
+import skytils.hylin.extension.getOptionalString
 import skytils.skytilsmod.Skytils
 import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.features.impl.handlers.Waypoint
@@ -51,6 +52,8 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
 
     companion object {
         private val gson: Gson = GsonBuilder().create()
+
+        private const val CATEGORY_INNER_VERTICAL_PADDING = 7.5
     }
 
     private val scrollComponent: ScrollComponent
@@ -145,7 +148,7 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
                 return@mapNotNull runCatching {
                     e as JsonObject
                     return@runCatching Waypoint(
-                        if (e.has("category")) e["category"].asString else null,
+                        e.getOptionalString("category").ifEmpty { null },
                         e["name"].asString,
                         BlockPos(
                             e["x"].asInt,
@@ -227,12 +230,12 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
             x = CenterConstraint()
             y = SiblingConstraint(5f)
             width = 90.percent()
-            height = ChildBasedRangeConstraint() + 2.pixels()
+            height = ChildBasedRangeConstraint() + (CATEGORY_INNER_VERTICAL_PADDING * 2).pixels()
         }.effect(OutlineEffect(Color(255, 255, 255, 100), 1f))
 
         val selectedComponent = CheckboxComponent(enabled).childOf(container).constrain {
             x = 7.5.pixels()
-            y = 0.pixels()
+            y = CATEGORY_INNER_VERTICAL_PADDING.pixels()
         }.apply {
             onValueChange { newValue: Any? ->
                 val categoryObj = categoryContainers[container] ?: error("no category found for UIContainer")
@@ -248,8 +251,9 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
 
         UIText(name).childOf(container).constrain {
             x = CenterConstraint()
-            y = 0.pixels()
+            y = CATEGORY_INNER_VERTICAL_PADDING.pixels()
             width = 30.percent()
+            height = 24.pixels()
         }
 
         categoryContainers[container] = Category(
@@ -298,19 +302,30 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
             y = CenterConstraint()
         }
 
-        val xComponent = UIText(pos.x.toString()).childOf(container).constrain {
-            x = SiblingConstraint(5f)
+        // Position the x, y, and z labels so that they are centered at the middle of the ScrollComponent
+        val coordinates = UIContainer().childOf(container).constrain {
+            x = CenterConstraint()
             y = CenterConstraint()
+            width = ChildBasedSizeConstraint()
+            height = ChildBasedMaxSizeConstraint()
         }
 
-        val yComponent = UIText(pos.y.toString()).childOf(container).constrain {
-            x = SiblingConstraint(5f)
+        val xComponent = UIText(pos.x.toString()).childOf(coordinates).constrain {
+            x = 0.pixels()
             y = CenterConstraint()
+            color = ConstantColorConstraint(Color.LIGHT_GRAY)
         }
 
-        val zComponent = UIText(pos.z.toString()).childOf(container).constrain {
+        val yComponent = UIText(pos.y.toString()).childOf(coordinates).constrain {
             x = SiblingConstraint(5f)
             y = CenterConstraint()
+            color = ConstantColorConstraint(Color.LIGHT_GRAY)
+        }
+
+        val zComponent = UIText(pos.z.toString()).childOf(coordinates).constrain {
+            x = SiblingConstraint(5f)
+            y = CenterConstraint()
+            color = ConstantColorConstraint(Color.LIGHT_GRAY)
         }
 
         entries[container] = Entry(category, selected, nameComponent, xComponent, yComponent, zComponent)

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
@@ -241,10 +241,11 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
                 val categoryObj = categoryContainers[container] ?: error("no category found for UIContainer")
                 // If this value change was triggered while updating the checkbox, don't update the child checkboxes.
                 // see `updateCheckbox()`
-                if (categoryObj.ignoreCheckboxValueChange) return@onValueChange
-                // When the category is checked or unchecked, all child waypoints will follow this change.
-                this.parent.childContainers.forEach {
-                    it.childrenOfType<CheckboxComponent>().firstOrNull()?.setState(newValue as Boolean)
+                if (!categoryObj.ignoreCheckboxValueChange) {
+                    // When the category is checked or unchecked, all child waypoints will follow this change.
+                    this.parent.childContainers.forEach {
+                        it.childrenOfType<CheckboxComponent>().firstOrNull()?.setState(newValue as Boolean)
+                    }
                 }
             }
         }
@@ -252,8 +253,7 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
         UIText(name).childOf(container).constrain {
             x = CenterConstraint()
             y = CATEGORY_INNER_VERTICAL_PADDING.pixels()
-            width = 30.percent()
-            height = 24.pixels()
+            height = 12.pixels()
         }
 
         categoryContainers[container] = Category(

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
@@ -161,7 +161,7 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
     private fun exportSelectedWaypoints() {
         val island = SkyblockIsland.values()[islandDropdown.getValue()]
 
-        val obj = exportToNewFormat(island)
+        val obj = exportAsJsonObject(island)
         val count = obj["categories"].asJsonArray.sumOf { it.asJsonObject["waypoints"].asJsonArray.size() }
         setClipboardString(Base64.encodeBase64String(gson.toJson(obj).encodeToByteArray()))
         EssentialAPI.getNotifications()
@@ -172,7 +172,7 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
             )
     }
 
-    private fun exportToNewFormat(island: SkyblockIsland): JsonObject {
+    private fun exportAsJsonObject(island: SkyblockIsland): JsonObject {
         val parentObj = JsonObject()
         val categoriesList = JsonArray()
 
@@ -199,28 +199,6 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
         }
         parentObj.add("categories", categoriesList)
         return parentObj
-    }
-
-    private fun exportToOldFormat(island: SkyblockIsland): JsonArray {
-        val arr = JsonArray()
-        entries.values.filter {
-            it.selected.checked
-        }.forEach {
-            runCatching {
-                arr.add(JsonObject().apply {
-                    addProperty("name", it.name.getText())
-                    addProperty("x", it.x.getText().toInt())
-                    addProperty("y", it.y.getText().toInt())
-                    addProperty("z", it.z.getText().toInt())
-                    addProperty("island", island.mode)
-                    addProperty("enabled", true)
-                    addProperty("color", Color.RED.rgb)
-                })
-            }.onFailure {
-                it.printStackTrace()
-            }
-        }
-        return arr
     }
 
     private fun loadWaypointsForSelection(selection: Int) {

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointShareGui.kt
@@ -239,7 +239,7 @@ class WaypointShareGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2) {
 
     private fun addNewCategory(
         name: String = "",
-        enabled: Boolean = true,
+        enabled: Boolean = true
     ): Category {
         val container = UIContainer().childOf(scrollComponent).constrain {
             x = CenterConstraint()

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
@@ -666,11 +666,9 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
     ) {
         fun toWaypoint() = Waypoint(
             name.getText(),
-            BlockPos(
-                x.getText().toInt(),
-                y.getText().toInt(),
-                z.getText().toInt()
-            ),
+            x.getText().toInt(),
+            y.getText().toInt(),
+            z.getText().toInt(),
             enabled.checked!!,
             color.getColor(),
             addedAt

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
@@ -40,6 +40,7 @@ import skytils.skytilsmod.core.PersistentSave
 import skytils.skytilsmod.core.TickTask
 import skytils.skytilsmod.features.impl.handlers.Waypoint
 import skytils.skytilsmod.features.impl.handlers.Waypoints
+import skytils.skytilsmod.gui.components.HelpComponent
 import skytils.skytilsmod.gui.components.SimpleButton
 import skytils.skytilsmod.utils.SBInfo
 import skytils.skytilsmod.utils.SkyblockIsland
@@ -226,13 +227,6 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             mc.displayGuiScreen(null)
         }
 
-        SimpleButton("New Waypoints").childOf(bottomButtons).constrain {
-            x = SiblingConstraint(5f)
-            y = 0.pixels()
-        }.onLeftClick {
-            addNewWaypoint()
-        }
-
         SimpleButton("New Category").childOf(bottomButtons).constrain {
             x = SiblingConstraint(5f)
             y = 0.pixels()
@@ -242,8 +236,10 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             addNewWaypoint(category)
         }
 
+        HelpComponent(window, "Waypoints are organized by category. To add a category, click the 'New Category' button. To create a new waypoint in a category, click the 'New Waypoint' button at the top of any category. Clicking the 'Remove' button at the top of a category will remove all waypoints in the category. Waypoints are separated by the island that they are displayed on, so if you don't see the waypoint that you're looking for, try changing the island in the dropdown menu in the top right corner. To share waypoints with someone else, click the 'Share' button in the bottom left corner.")
+
         SimpleButton("Share").childOf(window).constrain {
-            x = 5.pixels()
+            x = SiblingConstraint(5f)
             y = 5.pixels(alignOpposite = true)
         }.onLeftClick {
             mc.displayGuiScreen(null)

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
@@ -233,7 +233,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             y = 0.pixels()
         }.onLeftClick {
             // Add a new category and a new blank waypoint inside it.
-            val category = addNewCategory(name = "")
+            val category = addNewCategory(name = "", isExpanded = true)
             addNewWaypoint(category)
         }
 
@@ -284,7 +284,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             Waypoints.categories.filter {
                 it.island == island
             }.forEach {
-                val category = addNewCategory(it.name ?: "")
+                val category = addNewCategory(it.name ?: "", isExpanded = it.isExpanded)
                 for (waypoint in it.waypoints.sortedBy { w ->
                     SortingOptions.values()[SortingOptions.lastSelected].sortingBy(
                         w
@@ -306,6 +306,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
     private fun addNewCategory(
         name: String = "",
         enabled: Boolean = true,
+        isExpanded: Boolean
     ): Category {
         val container = UIContainer().childOf(scrollComponent).constrain {
             x = CenterConstraint()
@@ -374,15 +375,17 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
         }
 
         categoryContainers[container] = Category(
-            container,
-            enabledComponent,
-            nameComponent,
-            expandComponent,
-            newWaypointButton
+            container = container,
+            enabled = enabledComponent,
+            name = nameComponent,
+            expandComponent = expandComponent,
+            newWaypointButton = newWaypointButton,
+            isCollapsed = !isExpanded
         )
 
         // When children are added or removed, the category's checkbox should be updated to reflect those changes.
         container.children.addObserver { _, _ -> updateCheckbox(categoryContainers[container]) }
+        if (!isExpanded) collapse(categoryContainers[container]!!) // Update the "Collapse" button text if the category is collapsed to begin with
 
         return categoryContainers[container]!!
     }
@@ -492,6 +495,8 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
         category.children.add(container)
         entries[container] =
             Entry(category, enabled, nameComponent, xComponent, yComponent, zComponent, colorComponent, addedAt)
+
+        if (category.isCollapsed) container.hide(true)
     }
 
     private fun UIContainer.createSmallTextBox(placeholder: String, defaultText: String): UITextInput =

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
@@ -19,18 +19,19 @@
 package skytils.skytilsmod.gui
 
 import gg.essential.elementa.ElementaVersion
+import gg.essential.elementa.UIComponent
 import gg.essential.elementa.WindowScreen
 import gg.essential.elementa.components.ScrollComponent
 import gg.essential.elementa.components.UIContainer
 import gg.essential.elementa.components.UIText
+import gg.essential.elementa.components.Window
 import gg.essential.elementa.components.input.UITextInput
 import gg.essential.elementa.constraints.*
+import gg.essential.elementa.constraints.animation.Animations
 import gg.essential.elementa.dsl.*
 import gg.essential.elementa.effects.OutlineEffect
 import gg.essential.universal.UKeyboard
-import gg.essential.vigilance.gui.settings.CheckboxComponent
-import gg.essential.vigilance.gui.settings.ColorComponent
-import gg.essential.vigilance.gui.settings.DropDown
+import gg.essential.vigilance.gui.settings.*
 import gg.essential.vigilance.utils.onLeftClick
 import net.minecraft.util.BlockPos
 import skytils.skytilsmod.Skytils
@@ -42,6 +43,7 @@ import skytils.skytilsmod.features.impl.handlers.Waypoints
 import skytils.skytilsmod.gui.components.SimpleButton
 import skytils.skytilsmod.utils.SBInfo
 import skytils.skytilsmod.utils.SkyblockIsland
+import skytils.skytilsmod.utils.setState
 import skytils.skytilsmod.utils.toggle
 import java.awt.Color
 
@@ -54,6 +56,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
     private val searchBar: UITextInput
 
     private val entries = HashMap<UIContainer, Entry>()
+    private val categoryContainers = HashMap<UIContainer, Category>()
 
     init {
         scrollComponent = ScrollComponent(
@@ -80,6 +83,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             }.also {
                 it.onValueChange { s ->
                     loadWaypointsForSelection(s)
+                    expandAll()
                 }
             }
 
@@ -89,12 +93,18 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
                     x = SiblingConstraint(10f, true)
                 }.apply {
                     onValueChange {
+                        expandAll()
                         SortingOptions.lastSelected = it
                         val sorter = SortingOptions.values()[it]
-                        scrollComponent.sortChildren { c ->
-                            c as UIContainer
-                            val entry = entries[c] ?: error("no entry found for child")
-                            return@sortChildren sorter.sortingBy(entry.toWaypoint(SkyblockIsland.PrivateIsland))
+                        scrollComponent.allChildren.forEach { category ->
+                            category as UIContainer
+                            val uiContainers = category.childContainers.sortedBy { w ->
+                                val entry = entries[w] ?: error("no entry found for child")
+                                return@sortedBy sorter.sortingBy(entry.toWaypoint(SkyblockIsland.PrivateIsland))
+                            }
+                            // Remove and re-add the waypoints in the correct order
+                            category.children.removeAll(uiContainers)
+                            category.children.addAll(uiContainers)
                         }
                     }
                 }
@@ -103,41 +113,49 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             x = 2.pixels()
             y = 2.pixels()
             width = 20.percent()
-            height = 12.pixels()
+            height = 23.pixels()
         }.apply {
             onLeftClick {
                 grabWindowFocus()
             }
             onKeyType { _, _ ->
-                scrollComponent.allChildren.forEach { c ->
-                    c as UIContainer
-                    val entry = entries[c] ?: error("no entry found for child")
-                    if (entry.name.getText().contains(this@apply.getText())) c.unhide()
-                    else c.hide()
+                expandAll()
+                scrollComponent.allChildren.forEach { category ->
+                    category.childContainers.forEach { w ->
+                        val entry = entries[w] ?: error("no entry found for child")
+                        if (entry.name.getText().contains(this@apply.getText())) {
+                            w.unhide()
+                        } else {
+                            w.hide()
+                        }
+                    }
                 }
             }
         }
 
         SimpleButton("Toggle Visible").childOf(topButtons).constrain {
             x = 2.pixels()
-            y = 20.pixels()
+            y = 30.pixels()
             width = 100.pixels()
             height = 20.pixels()
         }.apply {
             onLeftClick {
-                val valid = scrollComponent.allChildren.mapNotNull { c ->
-                    c as UIContainer
-                    val entry = entries[c] ?: error("no entry found for child")
-                    if (entry.name.getText().contains(searchBar.getText())) return@mapNotNull entry
-                    else return@mapNotNull null
-                }
-                if (valid.any { it.enabled.checked }) {
-                    valid.forEach {
-                        if (it.enabled.checked) it.enabled.toggle()
-                    }
-                } else {
-                    valid.forEach {
-                        if (!it.enabled.checked) it.enabled.toggle()
+                if (expandAll()) { // if not all of the categories are expanded, expand them. this will run on the next button press.
+                    val valid = scrollComponent.allChildren.map { c ->
+                        c.childContainers.mapNotNull { w ->
+                            val entry = entries[w] ?: error("no entry found for child")
+                            if (entry.name.getText().contains(searchBar.getText())) return@mapNotNull entry
+                            else return@mapNotNull null
+                        }
+                    }.flatten()
+                    if (valid.any { it.enabled.checked }) {
+                        valid.forEach {
+                            if (it.enabled.checked) it.enabled.toggle()
+                        }
+                    } else {
+                        valid.forEach {
+                            if (!it.enabled.checked) it.enabled.toggle()
+                        }
                     }
                 }
             }
@@ -145,20 +163,45 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
 
         SimpleButton("Remove Visible").childOf(topButtons).constrain {
             x = 107.pixels()
-            y = 20.pixels()
+            y = 30.pixels()
             width = 100.pixels()
             height = 20.pixels()
         }.apply {
             onLeftClick {
                 scrollComponent.allChildren.forEach { c ->
                     c as UIContainer
-                    val entry = entries[c] ?: error("no entry found for child")
-                    if (entry.name.getText().contains(searchBar.getText())) {
-                        scrollComponent.removeChild(c)
-                        entries.remove(c)
+                    val category = categoryContainers[c] ?: error("no category found for UIContainer")
+                    if (category.isCollapsed) return@forEach // Collapsed categories aren't visible
+                    c.childContainers.forEach { w ->
+                        val entry = entries[w] ?: error("no entry found for child")
+                        if (entry.name.getText().contains(searchBar.getText())) {
+                            c.removeChild(w)
+                            category.children.remove(w)
+                            entries.remove(w)
+                            if (category.children.isEmpty()) {
+                                scrollComponent.removeChild(c)
+                                categoryContainers.remove(c)
+                            }
+                        }
                     }
                 }
             }
+        }
+
+        SimpleButton("Expand All").childOf(topButtons).constrain {
+            x = 2.pixels(alignOpposite = true)
+            y = 30.pixels()
+            width = 100.pixels()
+            height = 20.pixels()
+        }.onLeftClick { expandAll() }
+
+        SimpleButton("Collapse All").childOf(topButtons).constrain {
+            x = SiblingConstraint(5f, alignOpposite = true)
+            y = 30.pixels()
+            width = 100.pixels()
+            height = 20.pixels()
+        }.onLeftClick {
+            categoryContainers.values.forEach { collapse(it) }
         }
 
         UIText("Waypoints").childOf(window).constrain {
@@ -186,6 +229,15 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             y = 0.pixels()
         }.onLeftClick {
             addNewWaypoint()
+        }
+
+        SimpleButton("New Category").childOf(bottomButtons).constrain {
+            x = SiblingConstraint(5f)
+            y = 0.pixels()
+        }.onLeftClick {
+            // Add a new category and a new blank waypoint inside it.
+            val category = addNewCategory(name = "")
+            addNewWaypoint(category)
         }
 
         SimpleButton("Share").childOf(window).constrain {
@@ -222,34 +274,151 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             PersistentSave.markDirty<Waypoints>()
         }
         entries.clear()
+        categoryContainers.clear()
         scrollComponent.clearChildren()
         if (!isClosing) {
             val island = SkyblockIsland.values()[selection]
             Waypoints.waypoints.filter {
                 it.island == island
             }.sortedBy { SortingOptions.values()[SortingOptions.lastSelected].sortingBy(it) }.forEach {
-                addNewWaypoint(it.name, it.pos, it.enabled, it.color, it.addedAt)
+                addNewWaypoint(it.category ?: "Uncategorized", it.name, it.pos, it.enabled, it.color, it.addedAt)
             }
         }
     }
 
+    private fun addNewCategory(
+        name: String = "",
+        enabled: Boolean = true
+    ): Category {
+        val container = UIContainer().childOf(scrollComponent).constrain {
+            x = CenterConstraint()
+            y = SiblingConstraint(5f)
+            width = 90.percent()
+            height = ChildBasedRangeConstraint()
+        }.effect(OutlineEffect(Color(255, 255, 255, 100), 1f))
+
+        val enabledComponent = CheckboxComponent(enabled).childOf(container).constrain {
+            x = 7.5.pixels()
+            y = 0.pixels()
+        }.apply {
+            onValueChange { newValue: Any? ->
+                val categoryObj = categoryContainers[container] ?: error("no category found for UIContainer")
+                // If this value change was triggered while updating the checkbox, don't update the child checkboxes.
+                // see `updateCheckbox()`
+                if(categoryObj.ignoreCheckboxValueChange) return@onValueChange
+                // When the category is checked or unchecked, all child waypoints will follow this change.
+                (this.parent as UIContainer).childContainers.forEach {
+                    it.childrenOfType<CheckboxComponent>().firstOrNull()?.setState(newValue as Boolean)
+                }
+            }
+        }
+
+        SimpleButton("Remove").childOf(container).constrain {
+            x = SiblingConstraint(5f)
+            y = 0.pixels()
+        }.onLeftClick {
+            container.childContainers.forEach { entries.remove(it) } // remove all waypoints in this category from the list of entries
+            container.children.clear() // clear the children of this category's UIContainer
+            scrollComponent.removeChild(container) // remove this category's UIContainer from the ScrollComponent
+            categoryContainers.remove(container) // remove this category from the list of categories
+        }
+
+        val newWaypointButton = SimpleButton("New Waypoint").childOf(container).constrain {
+            x = SiblingConstraint(5f)
+            y = 0.pixels()
+        }
+
+        val nameComponent = UITextInput("Category Name").childOf(container).constrain {
+            x = CenterConstraint()
+            y = 0.pixels()
+            width = 30.percent()
+            height = 24.pixels()
+        }.apply {
+            onLeftClick {
+                grabWindowFocus()
+            }
+            setText(name)
+        }
+
+        val expandComponent = SimpleButton("Collapse").childOf(container).constrain {
+            x = 5.pixels(true)
+            y = 0.pixels()
+        }.apply {
+            onLeftClick {
+                val categoryObj = categoryContainers[container] ?: error("no category found for name")
+                if (categoryObj.isCollapsed) expand(categoryObj) else collapse(categoryObj)
+            }
+        }
+
+        newWaypointButton.onLeftClick {
+            expand(categoryContainers[container] ?: error("no category found for UIContainer"))
+            addNewWaypoint(categoryName = nameComponent.getText())
+        }
+
+        categoryContainers[container] = Category(
+            container,
+            enabledComponent,
+            nameComponent,
+            expandComponent,
+            newWaypointButton
+        )
+
+        container.children.addObserver { _, _ ->
+            // When children are added or removed, the category's checkbox should be updated to reflect those changes.
+            updateCheckbox(categoryContainers[container] ?: return@addObserver)
+        }
+
+        return categoryContainers[container]!!
+    }
+
     private fun addNewWaypoint(
+        categoryName: String = "Uncategorized",
         name: String = "",
         pos: BlockPos = mc.thePlayer.position,
         enabled: Boolean = true,
         color: Color = Color.RED,
         addedAt: Long = System.currentTimeMillis()
     ) {
-        val container = UIContainer().childOf(scrollComponent).constrain {
+        addNewWaypoint(
+            categoryContainers.entries.firstOrNull {
+                it.value.name.getText() == categoryName
+            }?.value ?: addNewCategory(categoryName),
+            name, pos, enabled, color, addedAt
+        )
+    }
+
+    private fun addNewWaypoint(
+        category: Category,
+        name: String = "",
+        pos: BlockPos = mc.thePlayer.position,
+        enabled: Boolean = true,
+        color: Color = Color.RED,
+        addedAt: Long = System.currentTimeMillis(),
+    ) {
+        val container = UIContainer().childOf(category.container).constrain {
             x = CenterConstraint()
             y = SiblingConstraint(5f)
-            width = 80.percent()
-            height = ChildBasedRangeConstraint()
-        }.effect(OutlineEffect(Color(0, 243, 255), 1f))
+            width = 90.percent()
+            height = ChildBasedMaxSizeConstraint()
+        }.effect(OutlineEffect(Color(0, 243, 255), 1f)).apply {
+            animateBeforeHide {
+                setHeightAnimation(Animations.IN_SIN, 0.2f, 0.pixels)
+            }
+            animateAfterUnhide {
+                setHeightAnimation(Animations.IN_SIN, 0.2f, ChildBasedMaxSizeConstraint())
+            }
+        }
 
         val enabled = CheckboxComponent(enabled).childOf(container).constrain {
             x = 7.5.pixels()
             y = CenterConstraint()
+        }.apply {
+            onValueChange {
+                Window.enqueueRenderOperation {
+                    // Update the checkbox *after* the `checked` state is updated.
+                    updateCheckbox(category)
+                }
+            }
         }
 
         val nameComponent = UITextInput("Waypoint Name").childOf(container).constrain {
@@ -298,7 +467,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
 
         val colorComponent = ColorComponent(color, true).childOf(container).constrain {
             x = SiblingConstraint(25f)
-            y = CenterConstraint()
+            y = 0.pixels()
             width = CoerceAtLeastConstraint(AspectConstraint(), 10.percentOfWindow)
         }.apply {
             setColor(color)
@@ -310,10 +479,16 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
         SimpleButton("Remove").childOf(container).constrain {
             x = 85.percent()
             y = CenterConstraint()
-            height = 40.pixels
         }.onLeftClick {
-            scrollComponent.removeChild(container)
+            category.children.remove(container)
+            category.container.removeChild(container)
             entries.remove(container)
+
+            // If the last waypoint in a category is deleted, remove that category.
+            if (category.children.isEmpty()) {
+                categoryContainers.remove(category.container)
+                scrollComponent.removeChild(category.container)
+            }
         }
 
         nameComponent.apply {
@@ -343,16 +518,9 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             }
         }
 
+        category.children.add(container)
         entries[container] =
-            Entry(enabled, nameComponent, xComponent, yComponent, zComponent, colorComponent, addedAt)
-    }
-
-    override fun onTick() {
-        for ((container, entry) in entries) {
-            if (entry.color.getHeight() == 20f) container.setHeight(9.5f.percent())
-            else container.setHeight(30f.percent())
-        }
-        super.onTick()
+            Entry(category, enabled, nameComponent, xComponent, yComponent, zComponent, colorComponent, addedAt)
     }
 
     override fun onScreenClose() {
@@ -360,16 +528,63 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
         loadWaypointsForSelection(-1, isClosing = true)
     }
 
+    private fun updateCheckbox(category: Category) {
+        category.ignoreCheckboxValueChange = true
+        category.enabled.setState(
+            category.children.all {
+                entries[it]?.enabled?.checked == true
+            }
+        )
+        category.ignoreCheckboxValueChange = false
+    }
+
+    private fun expandAll(): Boolean {
+        val allExpanded = categoryContainers.values.all { !it.isCollapsed }
+        categoryContainers.values.forEach(::expand)
+        return allExpanded
+    }
+
+    private fun expand(category: Category) = category.apply {
+        children.forEach {
+            if (entries[it]!!.name.getText().contains(this@WaypointsGui.searchBar.getText())) {
+                it.unhide(true)
+            } else it.hide()
+        }
+        isCollapsed = false
+        expandComponent.text.setText("Collapse")
+    }
+
+    private fun collapse(category: Category) = category.apply {
+        children.forEach { it.hide() }
+        isCollapsed = true
+        expandComponent.text.setText("Expand")
+    }
+
+    internal data class Category(
+        val container: UIContainer,
+        val enabled: CheckboxComponent,
+        val name: UITextInput,
+        val expandComponent: SimpleButton,
+        val newWaypointButton: SimpleButton,
+        val children: MutableList<UIContainer> = mutableListOf(),
+        var isCollapsed: Boolean = false,
+        var ignoreCheckboxValueChange: Boolean = false
+    )
+
     private data class Entry(
+        val category: Category,
         val enabled: CheckboxComponent,
         val name: UITextInput,
         val x: UITextInput,
         val y: UITextInput,
         val z: UITextInput,
         val color: ColorComponent,
-        val addedAt: Long
+        val addedAt: Long,
+        var colorPickerUp: Boolean = false,
+        var colorPickerDown: Boolean = false,
     ) {
         fun toWaypoint(island: SkyblockIsland) = Waypoint(
+            category.name.getText(),
             name.getText(),
             BlockPos(
                 x.getText().toInt(),
@@ -393,3 +608,9 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
         }
     }
 }
+
+// Gets the children of a UIContainer excluding all Vigilance components.
+// Used to get a list of all waypoints in a category, because categories contain
+// controls as well as multiple `UIContainer`s for the category's waypoints.
+internal val UIComponent.childContainers
+    get() = this.childrenOfType<UIContainer>().filter { it !is SettingComponent }

--- a/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/WaypointsGui.kt
@@ -288,13 +288,13 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
 
     private fun addNewCategory(
         name: String = "",
-        enabled: Boolean = true
+        enabled: Boolean = true,
     ): Category {
         val container = UIContainer().childOf(scrollComponent).constrain {
             x = CenterConstraint()
             y = SiblingConstraint(5f)
             width = 90.percent()
-            height = ChildBasedRangeConstraint()
+            height = ChildBasedRangeConstraint() + 2.pixels()
         }.effect(OutlineEffect(Color(255, 255, 255, 100), 1f))
 
         val enabledComponent = CheckboxComponent(enabled).childOf(container).constrain {
@@ -305,9 +305,9 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
                 val categoryObj = categoryContainers[container] ?: error("no category found for UIContainer")
                 // If this value change was triggered while updating the checkbox, don't update the child checkboxes.
                 // see `updateCheckbox()`
-                if(categoryObj.ignoreCheckboxValueChange) return@onValueChange
+                if (categoryObj.ignoreCheckboxValueChange) return@onValueChange
                 // When the category is checked or unchecked, all child waypoints will follow this change.
-                (this.parent as UIContainer).childContainers.forEach {
+                this.parent.childContainers.forEach {
                     it.childrenOfType<CheckboxComponent>().firstOrNull()?.setState(newValue as Boolean)
                 }
             }
@@ -330,7 +330,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
 
         val nameComponent = UITextInput("Category Name").childOf(container).constrain {
             x = CenterConstraint()
-            y = 0.pixels()
+            y = 5.pixels()
             width = 30.percent()
             height = 24.pixels()
         }.apply {
@@ -377,7 +377,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
         pos: BlockPos = mc.thePlayer.position,
         enabled: Boolean = true,
         color: Color = Color.RED,
-        addedAt: Long = System.currentTimeMillis()
+        addedAt: Long = System.currentTimeMillis(),
     ) {
         addNewWaypoint(
             categoryContainers.entries.firstOrNull {
@@ -399,13 +399,13 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             x = CenterConstraint()
             y = SiblingConstraint(5f)
             width = 90.percent()
-            height = ChildBasedMaxSizeConstraint()
+            height = ChildBasedMaxSizeConstraint() + 2.pixels()
         }.effect(OutlineEffect(Color(0, 243, 255), 1f)).apply {
             animateBeforeHide {
                 setHeightAnimation(Animations.IN_SIN, 0.2f, 0.pixels)
             }
             animateAfterUnhide {
-                setHeightAnimation(Animations.IN_SIN, 0.2f, ChildBasedMaxSizeConstraint())
+                setHeightAnimation(Animations.IN_SIN, 0.2f, ChildBasedMaxSizeConstraint() + 2.pixels())
             }
         }
 
@@ -467,7 +467,7 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
 
         val colorComponent = ColorComponent(color, true).childOf(container).constrain {
             x = SiblingConstraint(25f)
-            y = 0.pixels()
+            y = 1.pixels()
             width = CoerceAtLeastConstraint(AspectConstraint(), 10.percentOfWindow)
         }.apply {
             setColor(color)

--- a/src/main/kotlin/skytils/skytilsmod/gui/components/HelpComponent.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/components/HelpComponent.kt
@@ -1,0 +1,68 @@
+/*
+ * Skytils - Hypixel Skyblock Quality of Life Mod
+ * Copyright (C) 2022 Skytils
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package skytils.skytilsmod.gui.components
+
+import gg.essential.elementa.UIComponent
+import gg.essential.elementa.components.*
+import gg.essential.elementa.constraints.CenterConstraint
+import gg.essential.elementa.constraints.ChildBasedSizeConstraint
+import gg.essential.elementa.constraints.CoerceAtLeastConstraint
+import gg.essential.elementa.constraints.ConstantColorConstraint
+import gg.essential.elementa.dsl.*
+import gg.essential.elementa.effects.OutlineEffect
+import java.awt.Color
+
+/**
+ * A component with a "?" inside of a circle that displays a block of text when hovered.
+ */
+class HelpComponent(parentComponent: UIComponent, tooltipText: String) : UIBlock() {
+    init {
+        // Tooltip Block
+        constrain {
+            x = 5.pixels()
+            y = basicYConstraint { it.parent.getTop() - it.getHeight() - 6 }
+            height = ChildBasedSizeConstraint(4f)
+            width = ChildBasedSizeConstraint(4f)
+            color = ConstantColorConstraint(Color(112, 112, 112, 200))
+        }
+        effect(OutlineEffect(Color(0, 243, 255), 1f))
+        hide()
+
+        addChild(UIWrappedText(tooltipText).constrain {
+            x = 2.pixels()
+            y = 0.pixels()
+            width = CoerceAtLeastConstraint(50.percentOfWindow(), 200.pixels())
+        })
+
+        UICircle(7f).childOf(parentComponent).constrain {
+            x = 9.pixels()
+            y = basicYConstraint { it.parent.getBottom() - it.getHeight() - 2 }
+        }.addChildren(
+            UIText("?", true).constrain {
+                x = CenterConstraint()
+                y = CenterConstraint()
+            },
+            this
+        ).onMouseEnter {
+            this@HelpComponent.unhide()
+        }.onMouseLeave {
+            this@HelpComponent.hide()
+        }
+    }
+}

--- a/src/main/kotlin/skytils/skytilsmod/gui/components/MultiCheckboxComponent.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/components/MultiCheckboxComponent.kt
@@ -1,0 +1,119 @@
+/*
+ * Skytils - Hypixel Skyblock Quality of Life Mod
+ * Copyright (C) 2022 Skytils
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package skytils.skytilsmod.gui.components
+
+import gg.essential.elementa.components.UIBlock
+import gg.essential.elementa.components.UIImage
+import gg.essential.elementa.constraints.AspectConstraint
+import gg.essential.elementa.constraints.CenterConstraint
+import gg.essential.elementa.dsl.*
+import gg.essential.elementa.effects.OutlineEffect
+import gg.essential.universal.USound
+import gg.essential.vigilance.gui.VigilancePalette
+import gg.essential.vigilance.gui.settings.SettingComponent
+import gg.essential.vigilance.utils.onLeftClick
+
+/**
+ * Based on Vigilance under LGPL 3.0 license
+ * Modified to add an indeterminate state
+ * https://github.com/Sk1erLLC/Vigilance/blob/master/LICENSE
+ * @author Sk1er LLC
+ */
+class MultiCheckboxComponent(initialValue: Boolean?) : SettingComponent() {
+    var checked: Boolean? = initialValue
+        set(value) {
+            changeValue(value)
+            field = value
+            updateImage()
+        }
+
+    private val checkmark = UIImage.ofResourceCached("/vigilance/check.png").constrain {
+        x = CenterConstraint()
+        y = CenterConstraint()
+        width = 16.pixels()
+        height = 12.pixels()
+        color = getSettingColor().toConstraint()
+    } childOf this
+
+    private val indeterminate = UIBlock().constrain {
+        x = CenterConstraint()
+        y = CenterConstraint()
+        width = 16.pixels()
+        height = 2.pixels()
+        color = getSettingColor().toConstraint()
+    }.childOf(this).apply { hide(instantly = true) }
+
+    init {
+        constrain {
+            width = 20.pixels()
+            height = AspectConstraint()
+        }
+
+        effect(getOutlineEffect())
+
+        if (checked == null) {
+            indeterminate.unhide()
+        }
+
+        if (checked == false) {
+            checkmark.hide(instantly = true)
+        }
+
+        onLeftClick {
+            USound.playButtonPress()
+            checked = checked == false
+        }
+    }
+
+    private fun updateImage() {
+        removeEffect<OutlineEffect>()
+        effect(getOutlineEffect())
+
+        when (checked) {
+            null -> { // Indeterminate
+                checkmark.hide()
+                indeterminate.unhide()
+            }
+            true -> { // Enabled
+                indeterminate.hide()
+                checkmark.unhide()
+            }
+            else -> { // Disabled
+                checkmark.hide()
+                indeterminate.hide()
+            }
+        }
+    }
+
+    private fun getOutlineEffect() = OutlineEffect(getSettingColor(), 1f)
+
+    private fun getSettingColor() =
+        if (checked != false) VigilancePalette.getAccent() else VigilancePalette.getBrightDivider()
+
+
+    fun setState(newState: Boolean?) {
+        if (newState != checked) {
+            checked = newState
+        }
+    }
+
+    fun toggle() {
+        setState(checked == false)
+    }
+}

--- a/src/main/kotlin/skytils/skytilsmod/gui/components/SimpleButton.kt
+++ b/src/main/kotlin/skytils/skytilsmod/gui/components/SimpleButton.kt
@@ -24,6 +24,8 @@ import gg.essential.elementa.constraints.CenterConstraint
 import gg.essential.elementa.constraints.RelativeConstraint
 import gg.essential.elementa.constraints.animation.Animations
 import gg.essential.elementa.dsl.*
+import gg.essential.universal.USound
+import gg.essential.vigilance.utils.onLeftClick
 import java.awt.Color
 
 class SimpleButton @JvmOverloads constructor(val t: String, val h: Boolean = false, val w: Boolean = false) :
@@ -72,6 +74,8 @@ class SimpleButton @JvmOverloads constructor(val t: String, val h: Boolean = fal
                 text.constrain {
                     color = Color(14737632).toConstraint()
                 }
+            }.onLeftClick {
+                USound.playButtonPress()
             }
     }
 }

--- a/src/main/kotlin/skytils/skytilsmod/utils/ElementaUtil.kt
+++ b/src/main/kotlin/skytils/skytilsmod/utils/ElementaUtil.kt
@@ -1,0 +1,51 @@
+/*
+ * Skytils - Hypixel Skyblock Quality of Life Mod
+ * Copyright (C) 2022 Skytils
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package skytils.skytilsmod.utils
+
+import gg.essential.elementa.UIComponent
+import gg.essential.elementa.components.UIContainer
+import gg.essential.elementa.components.input.UITextInput
+import gg.essential.universal.UKeyboard
+import gg.essential.vigilance.gui.settings.SettingComponent
+
+/**
+ * When the tab key is pressed in this text field, [other] will grab the window's focus.
+ */
+fun UITextInput.setTabTarget(other: UIComponent) {
+    onKeyType { _, keyCode ->
+        if (keyCode == UKeyboard.KEY_TAB) other.grabWindowFocus()
+    }
+}
+
+/**
+ * Limit this [UITextInput] to only allow numerical characters and minus signs ("-")
+ */
+fun UITextInput.limitToNumericalCharacters() = apply {
+    onKeyType { _, _ ->
+        setText(getText().filter { c -> c.isDigit() || c == '-' })
+    }
+}
+
+/**
+ * Gets the children of a UIContainer excluding all Vigilance components.
+ * Used to get a list of all waypoints in a category, because categories contain
+ * controls as well as multiple [UIContainer] objects for the category's waypoints.
+ */
+val UIComponent.childContainers
+    get() = this.childrenOfType<UIContainer>().filter { it !is SettingComponent }

--- a/src/main/kotlin/skytils/skytilsmod/utils/apiTools.kt
+++ b/src/main/kotlin/skytils/skytilsmod/utils/apiTools.kt
@@ -142,21 +142,3 @@ object BlockPosObjectSerializer : KSerializer<BlockPos> {
             BlockPos(x, y, z)
         }
 }
-
-/**
- * Serializes/deserializes a [SkyblockIsland] based on its [SkyblockIsland.mode] to retain compatibility
- * with older saves that used the mode instead of a stringified enum constant name.
- */
-object SkyblockIslandModeSerializer : KSerializer<SkyblockIsland> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("SkyblockIsland", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): SkyblockIsland = decoder.decodeString().let { str ->
-        val sbIsland = SkyblockIsland.values().find { it.mode == str }
-        // Migrate old saves from the Blazing Fortress to the Crimson Isle
-        if (sbIsland == null && str == "combat_2") return SkyblockIsland.CrimsonIsle
-        else return sbIsland ?: error("Unexpected SkyblockIsland: $str")
-    }
-
-    override fun serialize(encoder: Encoder, value: SkyblockIsland) = encoder.encodeString(value.mode)
-
-}

--- a/src/main/kotlin/skytils/skytilsmod/utils/apiTools.kt
+++ b/src/main/kotlin/skytils/skytilsmod/utils/apiTools.kt
@@ -142,3 +142,21 @@ object BlockPosObjectSerializer : KSerializer<BlockPos> {
             BlockPos(x, y, z)
         }
 }
+
+/**
+ * Serializes/deserializes a [SkyblockIsland] based on its [SkyblockIsland.mode] to retain compatibility
+ * with older saves that used the mode instead of a stringified enum constant name.
+ */
+object SkyblockIslandModeSerializer : KSerializer<SkyblockIsland> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("SkyblockIsland", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): SkyblockIsland = decoder.decodeString().let { str ->
+        val sbIsland = SkyblockIsland.values().find { it.mode == str }
+        // Migrate old saves from the Blazing Fortress to the Crimson Isle
+        if (sbIsland == null && str == "combat_2") return SkyblockIsland.CrimsonIsle
+        else return sbIsland ?: error("Unexpected SkyblockIsland: $str")
+    }
+
+    override fun serialize(encoder: Encoder, value: SkyblockIsland) = encoder.encodeString(value.mode)
+
+}


### PR DESCRIPTION
Allows waypoints to be grouped into categories.
- Categories can be expanded, collapsed, and all of the waypoints in a category can be toggled at once
- New controls at the top of the GUI: expand all and collapse all
- Share waypoints GUI also displays categories
- The `Waypoints` PersistentSave has been updated to save categories if present, but it should be backwards-compatible with old saves/imported strings. Old mod versions shouldn't have an issue loading newer saves either because it's just a field added to each waypoint.

I've done a fair bit of testing, but this PR is marked as a draft until I'm sure that this won't cause a bunch of game crashes.

- One edge case that I've thought of: naming two categories to the same thing and re-opening the GUI will cause the categories to combine. Is this intended?
- What do you think of the animations? I like them but removing them is no issue.
- I'll add images soon, just wanted to publish this in case there was any feedback that I should address.

Have a great day! Skytils on top 🚀 
This resolves suggestions 2021, 2003, 1990, 1950, 1786, 1416, 1406, 1269, 1192, 1130, 1069, 1054, 952, 842