### PR TITLE
Highlight door opener

### DIFF
--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -180,6 +180,12 @@ object Config : Vigilant(
         category = "Dungeons", subcategory = "Quality of Life"
     )
     var autoRepartyOnDungeonEnd = false
+      @Property(
+        type = PropertyType.SWITCH, name = "Highlight Door Opener",
+        description = "Highlight the player that most recently opened a Wither Door on the spirit leap menu.",
+        category = "Dungeons", subcategory = "Quality of Life"
+    )
+    var highlightDoorOpener = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Death Counter",

--- a/src/main/kotlin/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/skytils/skytilsmod/core/Config.kt
@@ -180,12 +180,6 @@ object Config : Vigilant(
         category = "Dungeons", subcategory = "Quality of Life"
     )
     var autoRepartyOnDungeonEnd = false
-      @Property(
-        type = PropertyType.SWITCH, name = "Highlight Door Opener",
-        description = "Highlight the player that most recently opened a Wither Door on the spirit leap menu.",
-        category = "Dungeons", subcategory = "Quality of Life"
-    )
-    var highlightDoorOpener = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Death Counter",
@@ -593,6 +587,13 @@ object Config : Vigilant(
         category = "Dungeons", subcategory = "Quality of Life"
     )
     var spiritLeapNames = false
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Highlight Door Opener",
+        description = "Highlight the player that most recently opened a Wither Door on the spirit leap menu.",
+        category = "Dungeons", subcategory = "Quality of Life"
+    )
+    var highlightDoorOpener = false
 
     @Property(
         type = PropertyType.BUTTON, name = "Spirit Leap Highlights",
@@ -2653,6 +2654,8 @@ object Config : Vigilant(
         addDependency("messageTitle300Score", "createTitleOn300Score")
 
         addDependency("bloodHelperColor", "bloodHelper")
+
+        addDependency("highlightDoorOpener", "spiritLeapNames")
 
         addDependency("showNextBlaze", "blazeSolver")
         addDependency("lowestBlazeColor", "blazeSolver")

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/SpiritLeap.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/SpiritLeap.kt
@@ -88,12 +88,12 @@ class SpiritLeap : PersistentSave(File(Skytils.modDir, "spiritleap.json")) {
                     val scale = 0.9f
                     val scaleReset = 1 / scale
                     GlStateManager.pushMatrix()
-                    if (names.getOrDefault(name, false)) {
+                    if(name == doorOpener) {
+                        slot highlight 1174394112
+                    } else if (names.getOrDefault(name, false)) {
                         slot highlight 1174339584
                     } else if (classes.getOrDefault(dungeonClass, false)) {
                         slot highlight 1157693184
-                    } else if(name == doorOpener) {
-                        slot highlight 1174394112
                     }
                     GlStateManager.translate(0f, 0f, 299f)
                     Gui.drawRect(

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/SpiritLeap.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/SpiritLeap.kt
@@ -23,6 +23,7 @@ import net.minecraft.client.gui.Gui
 import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.init.Items
 import net.minecraft.inventory.ContainerChest
+import net.minecraftforge.client.event.ClientChatReceivedEvent
 import net.minecraftforge.event.world.WorldEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import skytils.hylin.skyblock.dungeons.DungeonClass
@@ -43,6 +44,9 @@ import java.util.*
 class SpiritLeap : PersistentSave(File(Skytils.modDir, "spiritleap.json")) {
 
     private val playerPattern = Regex("(?:\\[.+?] )?(?<name>\\w+)")
+    private val doorOpenedPattern = Regex("^(?:\\[.+?] )?(?<name>\\w+) opened a WITHER door!$")
+    private val bloodOpenedString = "§r§cThe §r§c§lBLOOD DOOR§r§c has been opened!§r"
+    private var doorOpener: String? = null
 
     companion object {
         val names = HashMap<String, Boolean>()
@@ -88,6 +92,8 @@ class SpiritLeap : PersistentSave(File(Skytils.modDir, "spiritleap.json")) {
                         slot highlight 1174339584
                     } else if (classes.getOrDefault(dungeonClass, false)) {
                         slot highlight 1157693184
+                    } else if(name == doorOpener) {
+                        slot highlight 1174394112
                     }
                     GlStateManager.translate(0f, 0f, 299f)
                     Gui.drawRect(
@@ -117,6 +123,13 @@ class SpiritLeap : PersistentSave(File(Skytils.modDir, "spiritleap.json")) {
                 GlStateManager.disableBlend()
             }
         }
+    }
+
+    @SubscribeEvent
+    fun onChatReceived(event: ClientChatReceivedEvent) {
+        if (!Skytils.config.highlightDoorOpener || !Utils.inDungeons || event.type == 2.toByte()) return
+        doorOpener = if (event.message.formattedText == bloodOpenedString) null
+        else (doorOpenedPattern.find(event.message.unformattedText)?.groups?.get("name")?.value ?: return)
     }
 
     @SubscribeEvent

--- a/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/SpiritLeap.kt
+++ b/src/main/kotlin/skytils/skytilsmod/features/impl/handlers/SpiritLeap.kt
@@ -88,7 +88,7 @@ class SpiritLeap : PersistentSave(File(Skytils.modDir, "spiritleap.json")) {
                     val scale = 0.9f
                     val scaleReset = 1 / scale
                     GlStateManager.pushMatrix()
-                    if(name == doorOpener) {
+                    if (name == doorOpener) {
                         slot highlight 1174394112
                     } else if (names.getOrDefault(name, false)) {
                         slot highlight 1174339584


### PR DESCRIPTION
When a wither door is opened, the player that opened the door will have their head highlighted in the Spirit Leap menu until a door is opened by a different player, or the blood door is opened.
This takes priority over other highlights