### PR TITLE
Fix GUI positions resetting

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/gui/LocationEditGui.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/gui/LocationEditGui.kt
@@ -162,6 +162,11 @@ open class LocationEditGui : GuiScreen(), ReopenableGUI {
             val y = (floatMouseY - yOffset) / sr.scaledHeight.toFloat()
             dragging!!.setPos(x, y)
             addResizeCorners(dragging!!)
+        } else return
+
+        dragging?.let {
+            GuiManager.GUIPOSITIONS[it.name] = it.pos
+            GuiManager.GUISCALES[it.name] = it.scale
         }
     }
 


### PR DESCRIPTION
GUI positions will reset every time the game is relaunched if they are not manually added to the config file. This PR assigns the gui element's position and scale to the `GUIPOSITIONS` and `GUISCALES` maps so that they are serialized and saved into the config file.

(huge PR, I know)