### PR TITLE
Update DSM/SBE Regex

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -550,6 +550,6 @@ class MiningFeatures {
         var waypoints = HashMap<String, BlockPos>()
         var deadCount = 0
         val SBE_DSM_PATTERN =
-            Regex("\\\$(SBECHWP\\b|DSMCHWP):(?<stringLocation>.*?)@(?<x>-?\\d+),(?<y>-?\\d+),(?<z>-?\\d+)")
+            Regex("\\\$(?:SBECHWP\\b|DSMCHWP):(?<stringLocation>.*?)@-(?<x>-?\\d+),(?<y>-?\\d+),(?<z>-?\\d+)")
     }
 }


### PR DESCRIPTION
Make the first group non-capturing, as it is not used, to save performance slightly.

Fixed an issue with regex where it processes as a negative number when it will never be a negative number. "@-" is always included, but does not signify a negative coordinate. This prevents existing issues where the location is placed off the map. 

- whalker