### PR TITLE
Fix creeper beam puzzle solver not works

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/CreeperSolver.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/CreeperSolver.kt
@@ -72,7 +72,7 @@ class CreeperSolver {
                     // Find creepers nearby
                     val creeperScan = AxisAlignedBB(x - 14, y - 8, z - 13, x + 14, y + 8, z + 13) // 28x16x26 cube
                     this.creeper = world.getEntitiesWithinAABB(EntityCreeper::class.java, creeperScan).find {
-                        !it.isInvisible && it.maxHealth == 20f && it.health == 20f && it.name == "Creeper"
+                        !it.isInvisible && it.maxHealth == 20f && it.health == 20f
                     }
                 } else {
                     val creeper = this.creeper!!


### PR DESCRIPTION
Since it returns localized name, if current Minecraft language has creeper named not "Creeper", check will fail.

Not sure if removing this check would break anything, but SkyblockMod doesn't have it.