### PR TITLE
Fix highlighting completed commissions

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -289,7 +289,7 @@ object MiningFeatures {
             if (Skytils.config.highlightCompletedCommissions && SBInfo.lastOpenContainerName.equals("Commissions")) {
                 if (item.displayName.startsWith("§6Commission #") && item.item == Items.writable_book) {
                     if (ItemUtil.getItemLore(item).any {
-                            it == "§7§eClick to claim rewards!"
+                            it == "§eClick to claim rewards!"
                         }) {
                         event.slot highlight Color(255, 0, 0)
                     }


### PR DESCRIPTION
There is no "§7" in claim line (anymore?)