### PR TITLE
Make "middleClickTerminals" false by default

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -829,7 +829,7 @@ object Config : Vigilant(
         description = "Replaces left clicks while on terminals with middle clicks.",
         category = "Dungeons", subcategory = "Terminal Solvers"
     )
-    var middleClickTerminals = true
+    var middleClickTerminals = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Change All to Same Color Solver",


### PR DESCRIPTION
Turn this setting off by default. Too many players download SkytilsMod and then on Floor 7, people in the in-game chat complain about something being wrong with their left click button.