### PR TITLE
Prevent NumberFormatException crash in Waypoint GUI

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/gui/WaypointsGui.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/gui/WaypointsGui.kt
@@ -446,9 +446,13 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
             setText(name)
         }
 
-        val xComponent = container.createSmallTextBox("X", pos.x.toString()).limitToNumericalCharacters()
-        val yComponent = container.createSmallTextBox("Y", pos.y.toString()).limitToNumericalCharacters()
-        val zComponent = container.createSmallTextBox("Z", pos.z.toString()).limitToNumericalCharacters()
+        val xComponent = container.createSmallTextBox("X", pos.x.toString())
+        val yComponent = container.createSmallTextBox("Y", pos.y.toString())
+        val zComponent = container.createSmallTextBox("Z", pos.z.toString())
+
+        listOf(xComponent, yComponent, zComponent).forEach {
+            it.limitToNumericalCharacters().colorIfNumeric(Color.WHITE, Color(170, 0, 0))
+        }
 
         val colorComponent = ColorComponent(color, true).childOf(container).constrain {
             x = SiblingConstraint(25f)
@@ -673,9 +677,9 @@ class WaypointsGui : WindowScreen(ElementaVersion.V1, newGuiScale = 2), Reopenab
     ) {
         fun toWaypoint() = Waypoint(
             name.getText(),
-            x.getText().toInt(),
-            y.getText().toInt(),
-            z.getText().toInt(),
+            x.getText().toIntOrNull() ?: 0,
+            y.getText().toIntOrNull() ?: 0,
+            z.getText().toIntOrNull() ?: 0,
             enabled.checked!!,
             color.getColor(),
             addedAt

--- a/src/main/kotlin/gg/skytils/skytilsmod/utils/ElementaUtil.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/utils/ElementaUtil.kt
@@ -23,6 +23,7 @@ import gg.essential.elementa.components.UIContainer
 import gg.essential.elementa.components.input.UITextInput
 import gg.essential.universal.UKeyboard
 import gg.essential.vigilance.gui.settings.SettingComponent
+import java.awt.Color
 
 /**
  * When the tab key is pressed in this text field, [other] will grab the window's focus.
@@ -40,6 +41,14 @@ fun UITextInput.limitToNumericalCharacters() = apply {
     onKeyType { _, _ ->
         setText(getText().filter { c -> c.isDigit() || c == '-' })
     }
+}
+
+/**
+ * Sets this [UITextInput] to [invalidColor] when a non-numeric value is entered and focus is lost.
+ * Resets to the default color when the input is made valid.
+ */
+fun UITextInput.colorIfNumeric(validColor: Color, invalidColor: Color) = apply {
+    onKeyType { _, _ -> setColor(if (getText().isInteger()) validColor else invalidColor) }
 }
 
 /**

--- a/src/main/kotlin/gg/skytils/skytilsmod/utils/StringUtils.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/utils/StringUtils.kt
@@ -43,3 +43,4 @@ fun String.toDashedUUID(): String {
 
 fun String.toTitleCase(): String = this.lowercase().replaceFirstChar { c -> c.titlecase() }
 fun String.splitToWords(): String = this.split('_', ' ').joinToString(" ") { it.toTitleCase() }
+fun String.isInteger(): Boolean = this.toIntOrNull() != null


### PR DESCRIPTION
Prevents a NumberFormatException crash in Waypoint GUI by casting non-numeric coordinates (e.g. "-" or "1-") to 0. 

Also attempts to notify user of formatting issue by marking coordinate text input fields in red when an invalid input is entered (and resetting when the invalid input is corrected).