### PR TITLE
Fixed splash health potions in dungeon sellable highlighter

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -207,11 +207,10 @@ object ItemFeatures {
                 if (Skytils.config.highlightDungeonSellableItems) {
                     if (event.slot.hasStack) {
                         val stack = event.slot.stack
-                        if (stack.displayName.contains("Health Potion")) event.slot highlight Color(255, 225, 30)
-                        else if (stack.displayName.containsAny(
+                        if (stack.displayName.containsAny(
                                 "Defuse Kit", "Lever", "Torch",
                                 "Stone Button", "Tripwire Hook", "Journal Entry",
-                                "Training Weights", "Mimic Fragment"
+                                "Training Weights", "Mimic Fragment", "Healing 8 Splash Potion", "Healing VIII Splash Potion"
                             )
                         ) event.slot highlight Color(255, 50, 150, 255)
                     }


### PR DESCRIPTION
Is there a reason health potions were highlighted a different colour to everything else? Also I don't know if SBA's "Replace Roman Numerals on Items" will affect this, so I accounted for both