### PR TITLE
Added MC version number to coremod AsmHelperLoadingPlugin

### DIFF
--- a/src/main/java/gg/skytils/skytilsmod/tweaker/SkytilsLoadingPlugin.java
+++ b/src/main/java/gg/skytils/skytilsmod/tweaker/SkytilsLoadingPlugin.java
@@ -31,6 +31,7 @@ import static gg.skytils.skytilsmod.tweaker.TweakerUtil.showMessage;
 
 @IFMLLoadingPlugin.Name("Skytils On Top")
 @IFMLLoadingPlugin.SortingIndex(69)
+@IFMLLoadingPlugin.MCVersion("1.8.9")
 public class SkytilsLoadingPlugin implements IFMLLoadingPlugin {
 
     public static final String missingDependency =


### PR DESCRIPTION
Fixing this error message:
`The coremod gg.skytils.skytilsmod.tweaker.SkytilsLoadingPlugin does not have a MCVersion annotation, it may cause issues with this version of Minecraft `