### PR TITLE
Blaze slayer fixes and features

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2453,6 +2453,14 @@ object Config : Vigilant(
     var attunementDisplay = false
 
     @Property(
+        PropertyType.SWITCH, name = "Ignore pacified blazes",
+        description = "Stops rendering faraway blazes when fighting the Inferno Demonlord if Smoldering Polarization is active.\n" +
+                "Do note that you will still be able to interact with them! /skytilsupdatepotioneffects",
+        category = "Slayer", subcategory = "Inferno Demonlord"
+    )
+    var ignorePacifiedBlazes = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Disable Cooldown Sounds",
         description = "Blocks the sound effect played while an item is on cooldown.",
         category = "Sounds", subcategory = "Abilities"

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2461,6 +2461,13 @@ object Config : Vigilant(
     var ignorePacifiedBlazes = false
 
     @Property(
+        type = PropertyType.SWITCH, name = "Show a warning when in Inferno Demonlord fire",
+        description = "Shows a warning when you are standing on Inferno Demonlord's fire.",
+        category = "Slayer", subcategory = "Inferno Demonlord"
+    )
+    var blazeFireWarning = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Disable Cooldown Sounds",
         description = "Blocks the sound effect played while an item is on cooldown.",
         category = "Sounds", subcategory = "Abilities"

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2232,6 +2232,16 @@ object Config : Vigilant(
     var voidRNG = 0f
 
     @Property(
+        type = PropertyType.DECIMAL_SLIDER, name = "Current Inferno RNG Meter",
+        description = "Internal value to store current Inferno Demonlord RNG meter",
+        category = "Slayer",
+        decimalPlaces = 1,
+        maxF = 100f,
+        hidden = true
+    )
+    var blazeRNG = 0f
+
+    @Property(
         type = PropertyType.SWITCH, name = "Click to Open Maddox Menu",
         description = "Open chat, then click anywhere on screen to open Maddox Menu.",
         category = "Slayer", subcategory = "Quality of Life"

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2453,7 +2453,7 @@ object Config : Vigilant(
     var attunementDisplay = false
 
     @Property(
-        PropertyType.SWITCH, name = "Ignore pacified blazes",
+        PropertyType.SWITCH, name = "Ignore Pacified Blazes",
         description = "Stops rendering faraway blazes when fighting the Inferno Demonlord if Smoldering Polarization is active.\n" +
                 "Do note that you will still be able to interact with them! /skytilsupdatepotioneffects",
         category = "Slayer", subcategory = "Inferno Demonlord"
@@ -2461,7 +2461,7 @@ object Config : Vigilant(
     var ignorePacifiedBlazes = false
 
     @Property(
-        type = PropertyType.SWITCH, name = "Show a warning when in Inferno Demonlord fire",
+        type = PropertyType.SWITCH, name = "Show a Warning when in Inferno Demonlord Fire",
         description = "Shows a warning when you are standing on Inferno Demonlord's fire.",
         category = "Slayer", subcategory = "Inferno Demonlord"
     )

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2446,6 +2446,13 @@ object Config : Vigilant(
     var totemPing = 0
 
     @Property(
+        PropertyType.SWITCH, name = "Attunement Display",
+        description = "Recolors the Inferno boss and demons depending on the correct dagger attunement.",
+        category = "Slayer", subcategory = "Inferno Demonlord"
+    )
+    var attunementDisplay = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Disable Cooldown Sounds",
         description = "Blocks the sound effect played while an item is on cooldown.",
         category = "Sounds", subcategory = "Abilities"

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
@@ -249,9 +249,9 @@ object SlayerFeatures : CoroutineScope {
         hasSlayerText = index != -1
         if (!lastTickHasSlayerText && hasSlayerText) {
             sidebarLines.elementAtOrNull(index - 1)?.let {
-                val boss = it.substringBeforeLast(" ")
+                val boss = it.substringBefore(" ")
                 val tier = it.substringAfterLast(" ")
-                expectedMaxHp = BossHealths[boss.substringBefore(" ")]?.get(tier) ?: 0
+                expectedMaxHp = BossHealths[boss]?.get(tier) ?: 0
             }
         }
         slayer?.tick(event)

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
@@ -35,6 +35,7 @@ import gg.skytils.skytilsmod.events.impl.CheckRenderEntityEvent
 import gg.skytils.skytilsmod.events.impl.PacketEvent.ReceiveEvent
 import gg.skytils.skytilsmod.events.impl.RenderHUDEvent
 import gg.skytils.skytilsmod.features.impl.handlers.MayorInfo
+import gg.skytils.skytilsmod.features.impl.handlers.PotionEffectTimers
 import gg.skytils.skytilsmod.utils.*
 import gg.skytils.skytilsmod.utils.NumberUtil.roundToPrecision
 import gg.skytils.skytilsmod.utils.NumberUtil.toRoman
@@ -497,17 +498,25 @@ object SlayerFeatures : CoroutineScope {
 
     @SubscribeEvent
     fun onCheckRender(event: CheckRenderEntityEvent<*>) {
-        if (!Skytils.config.hideOthersBrokenHeartRadiation || !event.entity.isInvisible || event.entity !is EntityGuardian) return
-        (slayer as? SeraphSlayer)?.run {
-            if (entity.isRiding) {
-                printDevMessage("Slayer is Riding", "slayer", "seraph", "seraphRadiation")
-                if (event.entity.getDistanceSqToEntity(entity) > 3.5 * 3.5) {
-                    printDevMessage("Guardian too far", "slayer", "seraph", "seraphRadiation")
+        if (Skytils.config.hideOthersBrokenHeartRadiation && event.entity.isInvisible && event.entity is EntityGuardian) {
+            (slayer as? SeraphSlayer)?.run {
+                if (entity.isRiding) {
+                    printDevMessage("Slayer is Riding", "slayer", "seraph", "seraphRadiation")
+                    if (event.entity.getDistanceSqToEntity(entity) > 3.5 * 3.5) {
+                        printDevMessage("Guardian too far", "slayer", "seraph", "seraphRadiation")
+                        event.isCanceled = true
+                    }
+                } else {
+                    printDevMessage("Slayer not riding, removing guardian", "slayer", "seraph", "seraphRadiation")
                     event.isCanceled = true
                 }
-            } else {
-                printDevMessage("Slayer not riding, removing guardian", "slayer", "seraph", "seraphRadiation")
-                event.isCanceled = true
+            }
+        }
+        if (Skytils.config.ignorePacifiedBlazes && event.entity is EntityBlaze && PotionEffectTimers.potionEffectTimers.containsKey("Smoldering Polarization")) {
+            (slayer as? DemonlordSlayer)?.run {
+                if (event.entity.getDistanceSqToEntity(mc.renderViewEntity) > 3 * 3 && event.entity != entity) {
+                    event.isCanceled = true
+                }
             }
         }
     }
@@ -1222,7 +1231,6 @@ object SlayerFeatures : CoroutineScope {
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTJmMjk5NDVhYTUzY2Q5NWEwOTc4YTYyZWYxYThjMTk3ODgwMzM5NWE4YWQ1YzA5MjFkOWNiZTVlMTk2YmI4YiJ9fX0="
 
             // Taken directly from https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes
-            // Ashen might be too dark?
             private val attunementColors = mapOf(
                 "ASHEN" to Color(85, 85, 85),
                 "CRYSTAL" to Color(85, 255, 255),

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
@@ -100,7 +100,11 @@ object SlayerFeatures : CoroutineScope {
     private val SPIDER_MINIBOSSES = arrayOf("§cTarantula Vermin", "§cTarantula Beast", "§4Mutant Tarantula")
     private val WOLF_MINIBOSSES = arrayOf("§cPack Enforcer", "§cSven Follower", "§4Sven Alpha")
     private val ENDERMAN_MINIBOSSES = arrayOf("Voidling Devotee", "Voidling Radical", "Voidcrazed Maniac")
-    private val timerRegex = Regex("(?:§8§lASHEN§8 ♨8 )?§c\\d+:\\d+(?:§r)?")
+    private val BLAZE_MINIBOSSES = arrayOf("Flare Demon", "Kindleheart Demon", "Burningsoul Demon")
+    // there might be a point replacing this with §c\d+:\d+(?:§r)?$ and only partially check for matches
+    // but that requires a more extensive testing of all skyblock timers,
+    // something I am not quite particularly fond of doing
+    private val timerRegex = Regex("(?:§[8bef]§l(ASHEN|CRYSTAL|AURIC|SPIRIT)§[8bef] ♨\\d|§4§lIMMUNE)? §c\\d+:\\d+(?:§r)?")
     private val totemRegex = Regex("§6§l(?<time>\\d+)s §c§l(?<hits>\\d+) hits")
     var slayer: Slayer<*>? = null
         set(value) {
@@ -137,7 +141,6 @@ object SlayerFeatures : CoroutineScope {
             ?: (if (Skytils.config.slayerCarryMode > 0) Skytils.config.slayerCarryMode.toRoman() else "")
     }
 
-
     init {
         SlayerArmorDisplayElement()
         SlayerDisplayElement()
@@ -172,7 +175,6 @@ object SlayerFeatures : CoroutineScope {
             }
         }
     }
-
 
     init {
         TickTask(4, repeats = true) {

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
@@ -974,6 +974,11 @@ object SlayerFeatures : CoroutineScope {
                                 }
                             }
                         }
+                        (this@Slayer as? DemonlordSlayer)?.let {
+                            if (potentialTimerEntities.removeIf { it == quaziiTimer || it == typhoeusTimer }) {
+                                printDevMessage("Ignored demon timers", "slayer")
+                            }
+                        }
                         if (potentialNameEntities.size == 1 && potentialTimerEntities.size == 1) {
                             return@TickTask potentialNameEntities.first() to potentialTimerEntities.first()
                         } else {
@@ -1271,10 +1276,6 @@ object SlayerFeatures : CoroutineScope {
                 }
             } else if (!entity.isInvisible && lastTickInvis) {
                 lastTickInvis = false
-                quazii = null
-                quaziiTimer = null
-                typhoeus = null
-                typhoeusTimer = null
             }
             super.tick(event)
         }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/SlayerFeatures.kt
@@ -222,6 +222,16 @@ object SlayerFeatures : CoroutineScope {
                             )
                             break
                         }
+                        if (boss.startsWith("Inferno Demonlord")) {
+                            BossStatus.setBossStatus(
+                                RNGMeter(
+                                    100f,
+                                    Skytils.config.blazeRNG,
+                                    ChatComponentText("§c§lInferno Demonlord RNG§r - §d${Skytils.config.blazeRNG}%")
+                                ), true
+                            )
+                            break
+                        }
                     }
                 }
             }
@@ -258,7 +268,7 @@ object SlayerFeatures : CoroutineScope {
                     RenderUtil.interpolate(event.entity.lastTickPosY, event.entity.posY, RenderUtil.getPartialTicks())
                 val z =
                     RenderUtil.interpolate(event.entity.lastTickPosZ, event.entity.posZ, RenderUtil.getPartialTicks())
-                if (ZOMBIE_MINIBOSSES.any { name.contains(it) }) {
+                if (ZOMBIE_MINIBOSSES.any { name.contains(it) } || BLAZE_MINIBOSSES.any { name.contains(it) }) {
                     drawOutlinedBoundingBox(
                         AxisAlignedBB(x - 0.5, y - 2, z - 0.5, x + 0.5, y, z + 0.5),
                         Color(0, 255, 255, 255),
@@ -374,6 +384,10 @@ object SlayerFeatures : CoroutineScope {
                         }
                         if (boss.startsWith("Voidgloom Seraph")) {
                             Skytils.config.voidRNG = rngMeter
+                            break
+                        }
+                        if (boss.startsWith("Inferno Demonlord")) {
+                            Skytils.config.blazeRNG = rngMeter
                             break
                         }
                     }

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/renderer/RendererLivingEntityHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/renderer/RendererLivingEntityHook.kt
@@ -26,6 +26,7 @@ import gg.skytils.skytilsmod.utils.Utils
 import gg.skytils.skytilsmod.utils.graphics.colors.ColorFactory
 import gg.skytils.skytilsmod.utils.withAlpha
 import net.minecraft.entity.Entity
+import net.minecraft.entity.EntityLiving
 import net.minecraft.entity.EntityLivingBase
 import net.minecraft.entity.monster.EntityEnderman
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
@@ -48,6 +49,15 @@ fun setColorMultiplier(
                 cir.returnValue = Skytils.config.seraphHitsPhaseColor.withAlpha(169)
             } else {
                 cir.returnValue = Skytils.config.seraphNormalPhaseColor.withAlpha(169)
+            }
+        }
+    } else if (Skytils.config.attunementDisplay && Utils.inSkyblock && entity is EntityLiving) {
+        (slayer as? SlayerFeatures.DemonlordSlayer)?.let {
+            if (entity == it.relevantEntity) {
+                entity.hurtTime = 0
+                it.relevantColor?.let {
+                    cir.returnValue = it.withAlpha(169)
+                }
             }
         }
     } else if (DungeonFeatures.livid == entity) {

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/renderer/RendererLivingEntityHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/renderer/RendererLivingEntityHook.kt
@@ -56,6 +56,8 @@ fun setColorMultiplier(
             if (entity == it.relevantEntity) {
                 entity.hurtTime = 0
                 it.relevantColor?.let {
+                    // Colors might be too hard to see because of the entities textures and colors,
+                    // as opposed to the enderman's almost fully black texture
                     cir.returnValue = it.withAlpha(169)
                 }
             }


### PR DESCRIPTION
Fixes blaze slayer features being broken and adds 3 new features to blaze slayer.
These are not meant to change how slayer detection or any of the other features work internally to not conflict with the feature/slayer branch. Instead, these are meant to be a temporary solution until SlayerFeatures gets rewritten.

Actual changes:
- Changed timerRegex to properly match all Inferno Demonlord bosses after the demons phase (it also matches demons now, for the Attunement Display feature)
- Updated Slayer Boss Hitbox to also draw around Inferno Demonlord minibosses
- Attunement Display: recolors the Inferno Demonlord or the appropiate demon according to the correct Attunement to use. Unlike the Voidgloom's phase display, the colors are not configurable because I don't think there is a reason since they match the Attunement. Ashen might be too hard to view compared to the rest however
- Ignore pacified blazes: stops rendering blaze entities further from 3 blocks from the player when Smoldering Polarization is active and the Inferno Demonlord is spawned
- Fire pit warning: displays a title and plays a ping when standing in the fire pit that the Inferno Demonlord spawns (that does a billion damage)

Note about the Slayer RNGesus Meter: still broken after the chat message changed. While fixable by keeping track of the open gui, checking if it's a slayer RNG Meter, checking which drop is selected and saving how much is the target XP of the drop, I figured that it'd be easier to save and download the XP required for each drop and use the chat message after changing RNG Meter drop to get it instead.