### PR TITLE
enable petitem confirmation by default

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2204,7 +2204,7 @@ object Config : Vigilant(
         description = "Requires a confirmation before using a pet item.",
         category = "Pets", subcategory = "Quality of Life"
     )
-    var petItemConfirmation = false
+    var petItemConfirmation = true
 
     @Property(
         type = PropertyType.DECIMAL_SLIDER, name = "Current Revenant RNG Meter",


### PR DESCRIPTION
This should be enabled by default. When I installed it, I didn't have pets yet. Today I gave my green bandana pet a farming xp boost by accident. RIP :-(