### PR TITLE
Reworked boss timer a bit and many things

### DIFF
--- a/src/main/java/gg/skytils/skytilsmod/mixins/transformers/util/MixinMouseHelper.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/transformers/util/MixinMouseHelper.java
@@ -19,15 +19,21 @@
 package gg.skytils.skytilsmod.mixins.transformers.util;
 
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
-import gg.skytils.skytilsmod.mixins.hooks.util.MouseHelperHookKt;
+import gg.skytils.skytilsmod.mixins.hooks.util.MouseHelperHook;
 import net.minecraft.util.MouseHelper;
+import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHelper.class)
 public class MixinMouseHelper {
-    @WrapWithCondition(method = "ungrabMouseCursor", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Mouse;setCursorPosition(II)V", remap = false))
-    private boolean shouldSetCursorPos(int newX, int newY) {
-        return MouseHelperHookKt.shouldResetMouseToCenter();
+    @Inject(method = "ungrabMouseCursor", at = @At("HEAD"), cancellable = true)
+    private void ungrabMouseCursor(CallbackInfo ci) {
+        if (MouseHelperHook.INSTANCE.shouldResetMouseToCenter()) {
+            ci.cancel();
+            Mouse.setGrabbed(false);
+        }
     }
 }

--- a/src/main/java/gg/skytils/skytilsmod/mixins/transformers/util/MixinMouseHelper.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/transformers/util/MixinMouseHelper.java
@@ -18,21 +18,16 @@
 
 package gg.skytils.skytilsmod.mixins.transformers.util;
 
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import gg.skytils.skytilsmod.mixins.hooks.util.MouseHelperHook;
 import net.minecraft.util.MouseHelper;
-import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHelper.class)
 public class MixinMouseHelper {
-    @Inject(method = "ungrabMouseCursor", at = @At("HEAD"), cancellable = true)
-    private void ungrabMouseCursor(CallbackInfo ci) {
-        if (MouseHelperHook.INSTANCE.shouldResetMouseToCenter()) {
-            ci.cancel();
-            Mouse.setGrabbed(false);
-        }
+    @WrapWithCondition(method = "ungrabMouseCursor", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Mouse;setCursorPosition(II)V", remap = false))
+    private boolean shouldSetCursorPos(int newX, int newY) {
+        return MouseHelperHook.INSTANCE.shouldResetMouseToCenter();
     }
 }

--- a/src/main/java/gg/skytils/skytilsmod/mixins/transformers/util/MixinMouseHelper.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/transformers/util/MixinMouseHelper.java
@@ -18,7 +18,6 @@
 
 package gg.skytils.skytilsmod.mixins.transformers.util;
 
-import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import gg.skytils.skytilsmod.mixins.hooks.util.MouseHelperHook;
 import net.minecraft.util.MouseHelper;
 import org.lwjgl.input.Mouse;

--- a/src/main/kotlin/gg/skytils/skytilsmod/Skytils.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/Skytils.kt
@@ -55,6 +55,7 @@ import gg.skytils.skytilsmod.listeners.ChatListener
 import gg.skytils.skytilsmod.listeners.DungeonListener
 import gg.skytils.skytilsmod.localapi.LocalAPI
 import gg.skytils.skytilsmod.mixins.extensions.ExtensionEntityLivingBase
+import gg.skytils.skytilsmod.mixins.hooks.util.MouseHelperHook
 import gg.skytils.skytilsmod.mixins.transformers.accessors.AccessorCommandHandler
 import gg.skytils.skytilsmod.mixins.transformers.accessors.AccessorGuiStreamUnavailable
 import gg.skytils.skytilsmod.mixins.transformers.accessors.AccessorSettingsGui
@@ -332,7 +333,8 @@ class Skytils {
             TriviaSolver,
             VisitorHelper,
             WaterBoardSolver,
-            Waypoints
+            Waypoints,
+            MouseHelperHook
         ).forEach(MinecraftForge.EVENT_BUS::register)
     }
 

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -169,13 +169,6 @@ object Config : Vigilant(
     var updateChannel = 2
 
     @Property(
-        type = PropertyType.SWITCH, name = "Blood Room Portal Timer",
-        description = "Displays time to portal on your HUD.",
-        category = "Dungeons", subcategory = "HUD"
-    )
-    var bloodPortalTimer = false
-
-    @Property(
         type = PropertyType.SWITCH, name = "Dungeon Crypts Counter",
         description = "Shows the amount of crypts destroyed on your HUD.",
         category = "Dungeons", subcategory = "HUD"
@@ -2149,13 +2142,6 @@ object Config : Vigilant(
         options = ["Normal", "Hidden", "Separate GUI"]
     )
     var hideAutopetMessages = 0
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide Pet Nametags",
-        description = "Hides the nametags above pets.",
-        category = "Pets", subcategory = "Quality of Life"
-    )
-    var hidePetNametags = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Highlight Active Pet",

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -383,6 +383,13 @@ object Config : Vigilant(
     var boxStarredMobs = false
 
     @Property(
+        type = PropertyType.COLOR, name = "Box Starred Mobs Color",
+        description = "Color of the bounding box for Starred Mobs.",
+        category = "Dungeons", subcategory = "Quality of Life"
+    )
+    var boxStarredMobsColor = Color(0, 255, 255, 255)
+
+    @Property(
         type = PropertyType.SWITCH, name = "Box Skeleton Masters",
         description = "Draws the bounding box for Skeleton Masters.",
         category = "Dungeons", subcategory = "Quality of Life"

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonFeatures.kt
@@ -551,7 +551,7 @@ object DungeonFeatures {
                         val name = event.entity.name
                         if (name.startsWith("§6✯ ") && name.endsWith("§c❤")) {
                             val (x, y, z) = RenderUtil.fixRenderPos(event.x, event.y, event.z)
-                            val color = Color(0, 255, 255, 255)
+                            val color = Skytils.config.boxStarredMobsColor
                             if ("Spider" in name) {
                                 RenderUtil.drawOutlinedBoundingBox(
                                     AxisAlignedBB(

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonFeatures.kt
@@ -105,7 +105,6 @@ object DungeonFeatures {
     private val lastBlockPos = BlockPos(7, 77, 34)
     private var startWithoutFullParty = false
     private var blazes = 0
-    private var secondsToPortal = 0f
     var hasClearedText = false
     private var terracottaSpawns = hashMapOf<BlockPos, Long>()
     private val dungeonMobSpawns = setOf(
@@ -124,7 +123,6 @@ object DungeonFeatures {
 
     init {
         LividGuiElement()
-        PortalTimer()
         SpiritBearSpawnTimer()
     }
 
@@ -139,7 +137,7 @@ object DungeonFeatures {
         } else if (isInTerracottaPhase && Skytils.config.terracottaRespawnTimer && dungeonFloor?.endsWith('6') == true) {
             if (event.old.block == Blocks.air && event.update.block == Blocks.flower_pot) {
                 // TODO: verify M6 time
-                terracottaSpawns[event.pos] = System.currentTimeMillis() + if (dungeonFloor == "F6") 15000 else 13000
+                terracottaSpawns[event.pos] = System.currentTimeMillis() + if (dungeonFloor == "F6") 15000 else 12000
             }
         }
     }
@@ -219,8 +217,6 @@ object DungeonFeatures {
                 GuiManager.createTitle("Spirit Pet", 20)
                 alertedSpiritPet = true
             }
-
-            secondsToPortal = (mc.thePlayer.maxInPortalTime / 20f) * (1 - mc.thePlayer.timeInPortal)
 
             if (Skytils.config.findCorrectLivid && !foundLivid) {
                 if (equalsOneOf(dungeonFloor, "F5", "M5")) {
@@ -685,8 +681,8 @@ object DungeonFeatures {
                     }
                 }
 
-                chestName == "Start Dungeon?" -> {
-                    if (!startWithoutFullParty && Skytils.config.noChildLeftBehind && event.slot?.stack?.displayName == "§aStart Dungeon?") {
+                chestName == "Ready Up" -> {
+                    if (!startWithoutFullParty && Skytils.config.noChildLeftBehind) {
                         val teamCount =
                             (DungeonListener.partyCountPattern.find(TabListUtils.tabEntries[0].second)?.groupValues?.get(
                                 1
@@ -741,51 +737,6 @@ object DungeonFeatures {
         blazes = 0
         hasClearedText = false
         terracottaSpawns.clear()
-    }
-
-    class PortalTimer : GuiElement("Blood Room Portal Timer", x = 0.05f, y = 0.4f) {
-        override fun render() {
-            if (!toggled || !Utils.inDungeons || DungeonTimer.bloodClearTime == -1L || DungeonTimer.bossEntryTime != -1L || mc.thePlayer?.isInsideOfMaterial(
-                    Material.portal
-                ) == false
-            ) return
-            val leftAlign = scaleX < sr.scaledWidth / 2f
-            val alignment = if (leftAlign) TextAlignment.LEFT_RIGHT else TextAlignment.RIGHT_LEFT
-            ScreenRenderer.fontRenderer.drawString(
-                "§a${secondsToPortal.roundToPrecision(2)}s",
-                if (leftAlign) 0f else width.toFloat(),
-                0f,
-                CommonColors.RED,
-                alignment,
-                SmartFontRenderer.TextShadow.NORMAL
-            )
-        }
-
-        override fun demoRender() {
-            val leftAlign = scaleX < sr.scaledWidth / 2f
-            val alignment = if (leftAlign) TextAlignment.LEFT_RIGHT else TextAlignment.RIGHT_LEFT
-            ScreenRenderer.fontRenderer.drawString(
-                "§aPortal: 3.99s",
-                if (leftAlign) 0f else 0f + width,
-                0f,
-                CommonColors.RED,
-                alignment,
-                SmartFontRenderer.TextShadow.NORMAL
-            )
-        }
-
-        override val height: Int
-            get() = ScreenRenderer.fontRenderer.FONT_HEIGHT
-
-        override val width: Int
-            get() = ScreenRenderer.fontRenderer.getStringWidth("Portal: 3.99s")
-
-        override val toggled: Boolean
-            get() = Skytils.config.bloodPortalTimer
-
-        init {
-            Skytils.guiManager.registerElement(this)
-        }
     }
 
     class SpiritBearSpawnTimer : GuiElement("Spirit Bear Spawn Timer", x = 0.05f, y = 0.4f) {

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonTimer.kt
@@ -39,12 +39,12 @@ object DungeonTimer {
     var dungeonStartTime = -1L
     var bloodOpenTime = -1L
     var bloodClearTime = -1L
-    var portalEnterTime = -1L
     var bossEntryTime = -1L
     var bossClearTime = -1L
     var phase1ClearTime = -1L
     var phase2ClearTime = -1L
     var phase3ClearTime = -1L
+    var terminalClearTime = -1L
     var phase4ClearTime = -1L
     var terraClearTime = -1L
     var giantsClearTime = -1L
@@ -141,7 +141,8 @@ object DungeonTimer {
                         ) {
                             add("§bMaxor took ${diff(phase1ClearTime, bossEntryTime)} seconds.")
                             add("§cStorm §btook ${diff(phase2ClearTime, phase1ClearTime)} seconds.")
-                            add("§6Goldor §btook ${diff(phase3ClearTime, phase2ClearTime)} seconds.")
+                            add("§eTerminals §btook ${diff(terminalClearTime, phase2ClearTime)} seconds.")
+                            add("§6Goldor §btook ${diff(phase3ClearTime, terminalClearTime)} seconds.")
                             add("§4Necron §btook ${diff(phase4ClearTime, phase3ClearTime)} seconds.")
                             if (DungeonFeatures.dungeonFloor == "M7") {
                                 add("§7Wither King §btook ${diff(bossClearTime, phase4ClearTime)} seconds.")
@@ -155,7 +156,7 @@ object DungeonTimer {
                 }
             }
 
-            Utils.equalsOneOf(DungeonFeatures.dungeonFloor, "F7", "M7") && message.startsWith("§r§4[BOSS] ") -> {
+            Utils.equalsOneOf(DungeonFeatures.dungeonFloor, "F7", "M7") && (message.startsWith("§r§4[BOSS] ") || message.startsWith("§r§aThe Core entrance ")) -> {
                 when {
                     message.endsWith("§r§cPathetic Maxor, just like expected.§r") && phase1ClearTime == -1L -> {
                         phase1ClearTime = System.currentTimeMillis()
@@ -164,17 +165,24 @@ object DungeonTimer {
                         )
                     }
 
-                    message.endsWith("§r§cAt least my son died by your hands.§r") && phase2ClearTime == -1L -> {
+                    message.endsWith("§r§cWho dares trespass into my domain?§r") && phase2ClearTime == -1L -> {
                         phase2ClearTime = System.currentTimeMillis()
                         if (Skytils.config.necronPhaseTimer) UChat.chat(
                             "§cStorm §btook ${diff(phase2ClearTime, phase1ClearTime)} seconds."
                         )
                     }
 
-                    message.endsWith("§r§c....§r") && phase3ClearTime == -1L -> {
+                    message.endsWith(" is opening!§r") && terminalClearTime == -1L -> {
+                        terminalClearTime = System.currentTimeMillis()
+                        if (Skytils.config.necronPhaseTimer) UChat.chat(
+                            "§eTerminals §btook ${diff(terminalClearTime, phase2ClearTime)} seconds."
+                        )
+                    }
+
+                    message.endsWith("§r§cYou went further than any human before, congratulations.§r") && phase3ClearTime == -1L -> {
                         phase3ClearTime = System.currentTimeMillis()
                         if (Skytils.config.necronPhaseTimer) UChat.chat(
-                            "§6Goldor §btook ${diff(phase3ClearTime, phase2ClearTime)} seconds."
+                            "§6Goldor §btook ${diff(phase3ClearTime, terminalClearTime)} seconds."
                         )
                     }
 
@@ -212,11 +220,11 @@ object DungeonTimer {
         dungeonStartTime = -1
         bloodOpenTime = -1
         bloodClearTime = -1
-        portalEnterTime = -1
         bossEntryTime = -1
         bossClearTime = -1
         phase1ClearTime = -1
         phase2ClearTime = -1
+        terminalClearTime = -1
         phase3ClearTime = -1
         phase4ClearTime = -1
         terraClearTime = -1
@@ -300,7 +308,9 @@ object DungeonTimer {
                     if (phase1ClearTime != -1L)
                         add("§cStorm: ${dungeonTimeFormat(((if (phase2ClearTime == -1L) if (scoreShownAt == -1L) System.currentTimeMillis() else scoreShownAt else phase2ClearTime) - phase1ClearTime) / 1000.0)}")
                     if (phase2ClearTime != -1L)
-                        add("§6Goldor: ${dungeonTimeFormat(((if (phase3ClearTime == -1L) if (scoreShownAt == -1L) System.currentTimeMillis() else scoreShownAt else phase3ClearTime) - phase2ClearTime) / 1000.0)}")
+                        add("§eTerminals: ${dungeonTimeFormat(((if (terminalClearTime == -1L) if (scoreShownAt == -1L) System.currentTimeMillis() else scoreShownAt else terminalClearTime) - phase2ClearTime) / 1000.0)}")
+                    if (terminalClearTime != -1L)
+                        add("§6Goldor: ${dungeonTimeFormat(((if (phase3ClearTime == -1L) if (scoreShownAt == -1L) System.currentTimeMillis() else scoreShownAt else phase3ClearTime) - terminalClearTime) / 1000.0)}")
                     if (phase3ClearTime != -1L)
                         add("§4Necron: ${dungeonTimeFormat(((if (phase4ClearTime == -1L) if (scoreShownAt == -1L) System.currentTimeMillis() else scoreShownAt else phase4ClearTime) - phase3ClearTime) / 1000.0)}")
                     if (phase4ClearTime != -1L && DungeonFeatures.dungeonFloor == "M7")
@@ -314,6 +324,7 @@ object DungeonTimer {
             val displayText = """
                 §bMaxor: 0s
                 §cStorm: 0s
+                §eTerminals: 0s
                 §6Goldor: 0s
                 §4Necron: 0s
                 §7Wither King: 0s

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/SimonSaysSolver.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/SimonSaysSolver.kt
@@ -94,8 +94,8 @@ object SimonSaysSolver {
 
                 var alpha = 0.5f
                 val x = pos.x - viewerX
-                val y = pos.y - viewerY + .318
-                val z = pos.z - viewerZ + .3
+                val y = pos.y - viewerY + .372
+                val z = pos.z - viewerZ + .308
                 val color = when (index) {
                     clickNeeded -> Color.GREEN
                     clickNeeded + 1 -> Color.YELLOW
@@ -106,7 +106,7 @@ object SimonSaysSolver {
 
                 RenderUtil.drawFilledBoundingBox(
                     matrixStack,
-                    AxisAlignedBB(x, y, z, x - .13, y + .322, z + .4),
+                    AxisAlignedBB(x, y, z, x - .13, y + .26, z + .382),
                     color,
                     alpha * Funny.alphaMult
                 )

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/SimonSaysSolver.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/SimonSaysSolver.kt
@@ -90,25 +90,22 @@ object SimonSaysSolver {
         if (Skytils.config.simonSaysSolver && clickNeeded < clickInOrder.size) {
             val matrixStack = UMatrixStack()
 
-            clickInOrder.forEachIndexed { index, pos ->
-
-                var alpha = 0.5f
+            for (i in clickNeeded until clickInOrder.size) {
+                val pos = clickInOrder[i]
                 val x = pos.x - viewerX
                 val y = pos.y - viewerY + .372
                 val z = pos.z - viewerZ + .308
-                val color = when (index) {
+                val color = when (i) {
                     clickNeeded -> Color.GREEN
                     clickNeeded + 1 -> Color.YELLOW
                     else -> Color.RED
                 }
 
-                if (index < clickNeeded) alpha = 0f
-
                 RenderUtil.drawFilledBoundingBox(
                     matrixStack,
                     AxisAlignedBB(x, y, z, x - .13, y + .26, z + .382),
                     color,
-                    alpha * Funny.alphaMult
+                    0.5f * Funny.alphaMult
                 )
             }
             GlStateManager.enableCull()

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/SimonSaysSolver.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/SimonSaysSolver.kt
@@ -64,6 +64,7 @@ object SimonSaysSolver {
                         if (state.block === Blocks.air) {
                             //println("Buttons on simon says were removed!")
                             clickNeeded = 0
+                            clickInOrder.clear()
                         } else if (state.block === Blocks.stone_button) {
                             if (old.block === Blocks.stone_button) {
                                 if (state.getValue(BlockButtonStone.POWERED)) {
@@ -88,17 +89,28 @@ object SimonSaysSolver {
 
         if (Skytils.config.simonSaysSolver && clickNeeded < clickInOrder.size) {
             val matrixStack = UMatrixStack()
-            val pos = clickInOrder[clickNeeded].west()
-            val x = pos.x - viewerX
-            val y = pos.y - viewerY
-            val z = pos.z - viewerZ
-            GlStateManager.disableCull()
-            RenderUtil.drawFilledBoundingBox(
-                matrixStack,
-                AxisAlignedBB(x, y, z, x + 1, y + 1, z + 1),
-                if (clickNeeded == clickInOrder.size - 1) Color.GREEN else Color.RED,
-                0.5f * Funny.alphaMult
-            )
+
+            clickInOrder.forEachIndexed { index, pos ->
+
+                var alpha = 0.5f
+                val x = pos.x - viewerX
+                val y = pos.y - viewerY + .318
+                val z = pos.z - viewerZ + .3
+                val color = when (index) {
+                    clickNeeded -> Color.GREEN
+                    clickNeeded + 1 -> Color.YELLOW
+                    else -> Color.RED
+                }
+
+                if (index < clickNeeded) alpha = 0f
+
+                RenderUtil.drawFilledBoundingBox(
+                    matrixStack,
+                    AxisAlignedBB(x, y, z, x - .13, y + .322, z + .4),
+                    color,
+                    alpha * Funny.alphaMult
+                )
+            }
             GlStateManager.enableCull()
         }
     }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/TerminalFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/terminals/TerminalFeatures.kt
@@ -64,7 +64,7 @@ object TerminalFeatures {
         if (chest is ContainerChest) {
             val inv = chest.lowerChestInventory
             val chestName = inv.displayName.unformattedText
-            if (chestName == "Navigate the maze!" || chestName == "Correct all the panes!") {
+            if (chestName == "Click the button on time!" || chestName == "Correct all the panes!") {
                 event.toolTip.clear()
             }
         }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/farming/FarmingFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/farming/FarmingFeatures.kt
@@ -28,6 +28,7 @@ import gg.skytils.skytilsmod.core.SoundQueue
 import gg.skytils.skytilsmod.core.TickTask
 import gg.skytils.skytilsmod.events.impl.PacketEvent.ReceiveEvent
 import gg.skytils.skytilsmod.features.impl.handlers.MayorInfo
+import gg.skytils.skytilsmod.utils.SBInfo
 import gg.skytils.skytilsmod.utils.Utils
 import gg.skytils.skytilsmod.utils.stripControlCodes
 import net.minecraft.client.gui.GuiChat
@@ -53,7 +54,7 @@ object FarmingFeatures {
 
     @SubscribeEvent
     fun onChat(event: ClientChatReceivedEvent) {
-        if (!Utils.inSkyblock || event.type == 2.toByte()) return
+        if (SBInfo.mode != "farming_1" || event.type == 2.toByte()) return
 
         val formatted = event.message.formattedText
         val unformatted = event.message.unformattedText.stripControlCodes()

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/farming/GardenFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/farming/GardenFeatures.kt
@@ -46,8 +46,7 @@ object GardenFeatures {
     )
     private val scythes = hashMapOf("SAM_SCYTHE" to 1, "GARDEN_SCYTHE" to 2)
 
-
-    // TODO: New visitors might not be spawned in after time is up if player is offline (needs confirmation)
+    // Only up to 1 visitor can spawn if the player is offline or out of the garden, following the same timer.
     private val visitorCount = Regex("^\\s*§r§b§lVisitors: §r§f\\((?<visitors>\\d+)\\)§r\$")
     private val nextVisitor = Regex("\\s*§r Next Visitor: §r§b(?:(?<min>\\d+)m )?(?<sec>\\d+)s§r")
     private var nextVisitorAt = -1L
@@ -84,11 +83,12 @@ object GardenFeatures {
                 }
 
                 if (nextVisitorAt != -1L) {
-                    // TODO: confirm the max count is 5
+                    // Max number of visitors on your island is 5. However, after the 5th visitor the timer keeps going so there can be a 6th one that spawns after the 5th visitor is gone.
                     if (lastKnownVisitorCount > 5) {
                         nextVisitorAt = -1L
                     } else if (System.currentTimeMillis() >= nextVisitorAt) {
                         // TODO: 15 seconds is not constant, changes based on unique visitors and when crops are broken, however, it provides a good measure for now with a reasonable difference in time
+                        // -0.1s per crop broken
                         nextVisitorAt += 15_000L
                         lastKnownVisitorCount++
                         UChat.chat(

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -648,7 +648,7 @@ object ItemFeatures {
                     }
             }
         }
-        if (Skytils.config.showPetCandies && item.item === Items.skull) {
+        if (Skytils.config.showPetCandies && item.item === Items.skull) { // TODO: Use NBT
             lore?.forEach { line ->
                 candyPattern.find(line)?.let {
                     stackTip = it.groups[1]!!.value

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
@@ -446,9 +446,9 @@ object MiscFeatures {
         if (!Utils.inSkyblock || event.phase != TickEvent.Phase.START || mc.thePlayer == null || mc.theWorld == null) return
 
         if (Skytils.config.playersInRangeDisplay) {
-            inRangePlayerCount = mc.theWorld.playerEntities.filterIsInstance<EntityOtherPlayerMP>().count {
-                it.uniqueID.version() == 4 && it.getDistanceSqToEntity(mc.thePlayer) <= 30 * 30
-            }
+            inRangePlayerCount = (mc.theWorld.playerEntities.filterIsInstance<EntityOtherPlayerMP>().count {
+                (it.uniqueID.version() == 4 || it.uniqueID.version() == 1) && it.getDistanceSqToEntity(mc.thePlayer) <= 30 * 30 // Nicked players have uuid v1, Watchdog has uuid v4
+            } - 1).coerceAtLeast(0) // The -1 is to remove watchdog from the list
         }
         if (Skytils.config.summoningEyeDisplay && SBInfo.mode == SkyblockIsland.TheEnd.mode) {
             placedEyes = PlacedSummoningEyeDisplay.SUMMONING_EYE_FRAMES.count {

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/PetFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/PetFeatures.kt
@@ -53,22 +53,6 @@ object PetFeatures {
     private var lastPetLockNotif: Long = 0
     var lastPet: String? = null
 
-
-    @SubscribeEvent
-    fun onCheckRender(event: CheckRenderEntityEvent<*>) {
-        if (!Utils.inSkyblock) return
-        if (event.entity is EntityArmorStand) {
-            val entity = event.entity
-            val name = entity.customNameTag
-            if (Skytils.config.hidePetNametags && name.startsWith("§8[§7Lv") && name.contains(
-                    "'s "
-                ) && !name.contains("❤") && !name.contains("Hit")
-            ) {
-                event.isCanceled = true
-            }
-        }
-    }
-
     @SubscribeEvent(priority = EventPriority.HIGHEST, receiveCanceled = true)
     fun onChat(event: ClientChatReceivedEvent) {
         if (!Utils.inSkyblock || event.type.toInt() == 2) return

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/util/MouseHelperHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/util/MouseHelperHook.kt
@@ -18,7 +18,6 @@
 
 package gg.skytils.skytilsmod.mixins.hooks.util
 
-import gg.essential.universal.UChat
 import gg.skytils.skytilsmod.Skytils
 import net.minecraft.client.Minecraft
 import net.minecraftforge.client.event.GuiOpenEvent

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/util/MouseHelperHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/util/MouseHelperHook.kt
@@ -19,30 +19,26 @@
 package gg.skytils.skytilsmod.mixins.hooks.util
 
 import gg.skytils.skytilsmod.Skytils
-import net.minecraft.client.Minecraft
-import net.minecraftforge.client.event.GuiOpenEvent
+import gg.skytils.skytilsmod.Skytils.Companion.mc
 import net.minecraft.client.gui.inventory.GuiChest
 import net.minecraft.client.gui.inventory.GuiContainer
+import net.minecraftforge.client.event.GuiOpenEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import net.minecraftforge.fml.common.gameevent.TickEvent
 
 object MouseHelperHook {
     private var lastOpen = -1L
-    private var guiWasNotNull = false
+
     @SubscribeEvent
     fun onGuiOpen(e: GuiOpenEvent) {
-        val oldGui = Minecraft.getMinecraft().currentScreen
-        if (e.gui is GuiChest && (oldGui is GuiContainer || oldGui == null)) {
+        val oldGui = mc.currentScreen
+        if (e.gui == null) {
+            lastOpen = -1L
+        } else if (e.gui is GuiChest && (oldGui is GuiContainer || oldGui == null)) {
             lastOpen = System.currentTimeMillis()
         }
     }
 
-    @SubscribeEvent
-    fun onTick(event: TickEvent.ClientTickEvent) {
-        guiWasNotNull = Minecraft.getMinecraft().currentScreen != null
-    }
-
     fun shouldResetMouseToCenter(): Boolean {
-        return Skytils.config.preventCursorReset && System.currentTimeMillis() - lastOpen <= 150 && guiWasNotNull
+        return Skytils.config.preventCursorReset && System.currentTimeMillis() - lastOpen <= 150
     }
 }

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/util/MouseHelperHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/util/MouseHelperHook.kt
@@ -18,8 +18,32 @@
 
 package gg.skytils.skytilsmod.mixins.hooks.util
 
+import gg.essential.universal.UChat
 import gg.skytils.skytilsmod.Skytils
+import net.minecraft.client.Minecraft
+import net.minecraftforge.client.event.GuiOpenEvent
+import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.client.gui.inventory.GuiContainer
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import net.minecraftforge.fml.common.gameevent.TickEvent
 
-fun shouldResetMouseToCenter(): Boolean {
-    return !Skytils.config.preventCursorReset
+object MouseHelperHook {
+    private var lastOpen = -1L
+    private var guiWasNotNull = false
+    @SubscribeEvent
+    fun onGuiOpen(e: GuiOpenEvent) {
+        val oldGui = Minecraft.getMinecraft().currentScreen
+        if (e.gui is GuiChest && (oldGui is GuiContainer || oldGui == null)) {
+            lastOpen = System.currentTimeMillis()
+        }
+    }
+
+    @SubscribeEvent
+    fun onTick(event: TickEvent.ClientTickEvent) {
+        guiWasNotNull = Minecraft.getMinecraft().currentScreen != null
+    }
+
+    fun shouldResetMouseToCenter(): Boolean {
+        return Skytils.config.preventCursorReset && System.currentTimeMillis() - lastOpen <= 150 && guiWasNotNull
+    }
 }


### PR DESCRIPTION
+ Fixed Terracotta time in M6 (maybe)
+ Improved Simon Says Solver
+ Fixed noChildLeftBehind (GUI name is different)
+ Reworked M7 Boss Timer (Added a Terminals Split, changed messages to more accepted split messages)
+ Allowed to change box starred mobs color
+ Improved prevent cursor reset to not always reset
= Hide Tooltip in Melody Terminal instead of Maze (Good night maze, not coming back)
= Fixed legion display being wrong sometimes
 - Removed Portal Entry Timer and Hide Pet Nametags (Portal is now instant and you can hide pet nametags in pet settings)
 

