### PR TITLE
Fix: Disabled HOTM perks aren't being detected

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -283,7 +283,7 @@ object MiningFeatures {
         if (event.slot.hasStack) {
             val item = event.slot.stack
             if (Skytils.config.highlightDisabledHOTMPerks && SBInfo.lastOpenContainerName == "Heart of the Mountain") {
-                if (ItemUtil.getItemLore(item).any { it == "§cDISABLED" }) {
+                if (ItemUtil.getItemLore(item).any { it == "§c§lDISABLED" }) {
                     event.slot highlight Color(255, 0, 0)
                 }
             }


### PR DESCRIPTION
Hypixel changed the formatting again

```
{
    id: "minecraft:diamond",
    Count: 1b,
    tag: {
        display: {
            Lore: ["§7Level 100", "", "§7Gain §a+§a3,964 §abase Powder", "§a§7from the first ore you mine", "§7every day. Works for all Powder", "§7types.", "", "§c§lDISABLED", "", "§eRight-click to §aenable§e!"],
            Name: "§aDaily Powder"
        }
    },
    Damage: 0s
}
```
