### PR TITLE
Feature: Add stacking enchantment stack size

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -1530,6 +1530,13 @@ object Config : Vigilant(
     var showStarCount = false
 
     @Property(
+        type = PropertyType.SWITCH, name = "Show Stacking Enchant Tier",
+        description = "Displays an item's stacking enchant tier as the stack size. Items with dungeon stars are ignored.",
+        category = "Miscellaneous", subcategory = "Items"
+    )
+    var showStackingEnchant = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Stacking Enchant Progress Display",
         description = "Displays the progress for the held item's stacking enchant.",
         category = "Miscellaneous", subcategory = "Items"

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -656,6 +656,16 @@ object ItemFeatures {
                 }
             }
         }
+        if (Skytils.config.showStackingEnchant && getExtraAttributes(item)?.let { ItemUtil.getStarCount(it) < 1} == true) { //" == true" because nullability, ignore items with dungeon stars property
+            also {
+                val extraAttr: NBTTagCompound = getExtraAttributes(item) ?: return@also
+                val enchantments = extraAttr.getCompoundTag("enchantments")
+                val stacking =
+                    EnchantUtil.enchants.find { it is StackingEnchant && extraAttr.hasKey(it.nbtNum) } as? StackingEnchant
+                        ?: return@also //right now items that haven't gotten any relevant skill xp won't get the stack size
+                stackTip = enchantments.getInteger(stacking.nbtName).toString()
+            }
+        }
         if (stackTip.isNotEmpty()) {
             GlStateManager.disableLighting()
             GlStateManager.disableDepth()


### PR DESCRIPTION
As some items have dungeon stars, I decided to let dungeon stars take priority.

Nullability-related Kotlin syntax is still not quite my forte, so if there's any revisions necessary, let me know.