### PR TITLE
Feature: Museum IRL Value on Tooltip

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -1745,6 +1745,13 @@ object Config : Vigilant(
     var usePlayerSkin = false
 
     @Property(
+        type = PropertyType.SWITCH, name = "Show IRL Value of Museum",
+        description = "Shows the IRL value of your museum in the Museum Appraisal menu in USD. Requires \"Fetch Lowest BIN Prices\" to be enabled.",
+        category = "Miscellaneous", subcategory = "Other"
+    )
+    var showIrlValueOfMuseum = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Custom Auction Price Input",
         description = "Displays Skytils' own auction input GUI instead of a sign.",
         category = "Miscellaneous", subcategory = "Quality of Life"

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
@@ -408,8 +408,9 @@ object MiscFeatures {
             val chest = player.openContainer as ContainerChest
             val inventory = chest.lowerChestInventory
             val chestName = inventory.displayName.unformattedText
+            val itemName = ItemUtil.getDisplayName(event.itemStack)
             if (chestName.equals("Storage") && Skytils.config.hideTooltipsOnStorage) {
-                if (ItemUtil.getDisplayName(event.itemStack).containsAny(
+                if (itemName.containsAny(
                         "Backpack",
                         "Ender Chest",
                         "Locked Page"
@@ -417,7 +418,7 @@ object MiscFeatures {
                 )
                     event.toolTip.clear()
             }
-            if (chestName.equals("Museum Appraisal") && Skytils.config.showIrlValueOfMuseum && Skytils.config.fetchLowestBINPrices) {
+            if (chestName.equals("Museum Appraisal") && itemName.contains("Museum Appraisal Service") && Skytils.config.showIrlValueOfMuseum && Skytils.config.fetchLowestBINPrices) {
                 also {
                     for (i in event.toolTip.indices) {
                         val line = event.toolTip[i]

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
@@ -100,7 +100,6 @@ object MiscFeatures {
     private val hubSpawnPoint = BlockPos(-2, 70, -69)
     private val bestiaryTitleRegex = Regex("(?:\\(\\d+/\\d+\\) )?(?:Bestiary ➜ (?!Fishing)|Fishing ➜ )|Search Results")
     private val coinsRegex = ".*((§.)(?<coins>(\\d([,.])?)+) Coins).*".toRegex()
-    private val boosterCookieCost = AuctionData.lowestBINs["BOOSTER_COOKIE"] ?: 1.0 // most of the skytils code opts for "?: 0.0", but since this code block divides by zero later, opt for "?: 1.0" instead
     private const val gemsPerCookie = 325.0 //see wiki.hypixel.net/BOOSTER_COOKIE
     private const val gemsPerSmallestBundle = 675.0 //see store.hypixel.net
     private const val usdPerSmallestBundle = 4.99 //see store.hypixel.net
@@ -420,6 +419,7 @@ object MiscFeatures {
             }
             if (chestName.equals("Museum Appraisal") && itemName.contains("Museum Appraisal Service") && Skytils.config.showIrlValueOfMuseum && Skytils.config.fetchLowestBINPrices) {
                 also {
+                    val boosterCookieCost = AuctionData.lowestBINs["BOOSTER_COOKIE"] ?: 1.0 // most of the skytils code opts for "?: 0.0", but since this code block divides by zero later, opt for "?: 1.0" instead
                     for (i in event.toolTip.indices) {
                         val line = event.toolTip[i]
                         if (line.matches(coinsRegex)) {


### PR DESCRIPTION
Complements NEU's `/pv` calculations, which are based on unsoulbound value.

Proof of above sentence:
![](https://github.com/Skytils/SkytilsMod/assets/51521765/2a1d7b56-2643-4846-bc60-fdf1f9afb289)
![](https://github.com/Skytils/SkytilsMod/assets/51521765/d14c07a6-fd69-44cf-9194-8f7aa1fd88ee)
![](https://github.com/Skytils/SkytilsMod/assets/51521765/87e3a211-add6-4723-b3be-dd5515ea49bd)
![](https://github.com/Skytils/SkytilsMod/assets/51521765/c2356072-e7ce-4803-8847-30895fdeb4f6)

Demo:
![](https://github.com/Skytils/SkytilsMod/assets/51521765/b79125c2-e08c-4683-9afd-ef15e8bf985e)