### PR TITLE
Feature(s): Click prevention on a few things (restores #430)

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2067,8 +2067,8 @@ object Config : Vigilant(
     var mayorVotePerkThreshold = 1
 
     @Property(
-        type = PropertyType.SWITCH, name = "Wardrobe Unequiping Prevention",
-        description = "Prevents you from unequiping your currently worn wardrobe slot without holding the Alt key. Does not override NEU's Wardrobe Keybinds.",
+        type = PropertyType.SWITCH, name = "Wardrobe Unequipping Prevention",
+        description = "Prevents you from unequipping your currently worn wardrobe slot without holding the Alt key. Does not override NEU's Wardrobe Keybinds.",
         category = "Miscellaneous", subcategory = "Quality of Life"
     )
     var wardrobeUnequipPrevent = false

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2053,14 +2053,14 @@ object Config : Vigilant(
 
     @Property(
     type = PropertyType.SWITCH, name = "Abiphone Call Prevention",
-    description = "Prevents you from calling your Abiphone contacts without holding the Alt key.",
+    description = "Prevents you from calling your Abiphone contacts without holding the Tab key.",
     category = "Miscellaneous", subcategory = "Quality of Life"
     )
     var abiphoneCallPrevention = false
 
     @Property(
         type = PropertyType.NUMBER, name = "Mayor Voting Perk Threshold",
-        description = "Prevents you from voting for mayors with fewer than this many perks. Set to \"1\" to disable. Hold the Alt key when voting to override this threshold.",
+        description = "Prevents you from voting for mayors with fewer than this many perks. Set to \"1\" to disable. Hold the Tab key when voting to override this threshold.",
         category = "Miscellaneous", subcategory = "Quality of Life",
         min = 1, max = 3
     )
@@ -2068,10 +2068,17 @@ object Config : Vigilant(
 
     @Property(
         type = PropertyType.SWITCH, name = "Wardrobe Unequipping Prevention",
-        description = "Prevents you from unequipping your currently worn wardrobe slot without holding the Alt key. Does not override NEU's Wardrobe Keybinds.",
+        description = "Prevents you from unequipping your currently worn wardrobe slot without holding the Tab key. Does not override NEU's Wardrobe Keybinds.",
         category = "Miscellaneous", subcategory = "Quality of Life"
     )
     var wardrobeUnequipPrevent = false
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Pickup Minion Prevention",
+        description = "Prevents you from picking up your minion without holding the Tab key.",
+        category = "Miscellaneous", subcategory = "Quality of Life"
+    )
+    var pickupMinionPrevent = false
 
     @Property(
         type = PropertyType.SWITCH, name = "Spider's Den Rain Timer",

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2052,6 +2052,14 @@ object Config : Vigilant(
     var protectStarredItems = false
 
     @Property(
+    type = PropertyType.SWITCH, name = "Abiphone Call Prevention",
+    description = "Prevents you from calling your Abiphone contacts without holding the Alt key.",
+    category = "Miscellaneous", subcategory = "Quality of Life",
+    searchTags = ["Abiphone"]
+    )
+    var abiphoneCallPrevention = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Spider's Den Rain Timer",
         description = "Shows the duration of rain in the Spider's Den.",
         category = "Miscellaneous", subcategory = "Quality of Life"

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2060,7 +2060,7 @@ object Config : Vigilant(
 
     @Property(
         type = PropertyType.NUMBER, name = "Mayor Voting Perk Threshold",
-        description = "Prevents you from voting for mayors with fewer than this many perks. Set to \"1\" to disable.",
+        description = "Prevents you from voting for mayors with fewer than this many perks. Set to \"1\" to disable. Hold the Alt key when voting to override this threshold.",
         category = "Miscellaneous", subcategory = "Quality of Life",
         min = 1, max = 3
     )

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2067,6 +2067,13 @@ object Config : Vigilant(
     var mayorVotePerkThreshold = 1
 
     @Property(
+        type = PropertyType.SWITCH, name = "Wardrobe Unequiping Prevention",
+        description = "Prevents you from unequiping your currently worn wardrobe slot without holding the Alt key. Does not override NEU's Wardrobe Keybinds.",
+        category = "Miscellaneous", subcategory = "Quality of Life"
+    )
+    var wardrobeUnequipPrevent = false
+
+    @Property(
         type = PropertyType.SWITCH, name = "Spider's Den Rain Timer",
         description = "Shows the duration of rain in the Spider's Den.",
         category = "Miscellaneous", subcategory = "Quality of Life"

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2054,10 +2054,17 @@ object Config : Vigilant(
     @Property(
     type = PropertyType.SWITCH, name = "Abiphone Call Prevention",
     description = "Prevents you from calling your Abiphone contacts without holding the Alt key.",
-    category = "Miscellaneous", subcategory = "Quality of Life",
-    searchTags = ["Abiphone"]
+    category = "Miscellaneous", subcategory = "Quality of Life"
     )
     var abiphoneCallPrevention = false
+
+    @Property(
+        type = PropertyType.NUMBER, name = "Mayor Voting Perk Threshold",
+        description = "Prevents you from voting for mayors with fewer than this many perks. Set to \"1\" to disable.",
+        category = "Miscellaneous", subcategory = "Quality of Life",
+        min = 1, max = 3
+    )
+    var mayorVotePerkThreshold = 1
 
     @Property(
         type = PropertyType.SWITCH, name = "Spider's Den Rain Timer",

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -265,14 +265,20 @@ object ItemFeatures {
             if (event.slot != null && event.slot.hasStack) {
                 val item = event.slot.stack ?: return
                 val extraAttr = getExtraAttributes(item)
+                val chestName = event.chestName
                 if (Skytils.config.stopClickingNonSalvageable) {
-                    if (event.chestName.startsWith("Salvage") && extraAttr != null) {
+                    if (chestName.startsWith("Salvage") && extraAttr != null) {
                         if (!extraAttr.hasKey("baseStatBoostPercentage") && !item.displayName.contains("Salvage") && !item.displayName.contains(
                                 "Essence"
                             )
                         ) {
                             event.isCanceled = true
                         }
+                    }
+                }
+                if (Skytils.config.abiphoneCallPrevention && getItemLore(item).isNotEmpty()) {
+                    if ((getItemLore(item).any { it.contains("click to call!") }) && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))) {
+                        event.isCanceled = true
                     }
                 }
             }
@@ -412,6 +418,16 @@ object ItemFeatures {
                     gems.getString("${it}_gem").ifEmpty { it.substringBeforeLast("_") }.toTitleCase()
                 }"
             })
+        }
+        if (Skytils.config.abiphoneCallPrevention && event.toolTip.any { it.contains("click to call!") }) {
+            also {
+                for (i in event.toolTip.indices) {
+                    if (event.toolTip[i].contains("click to call!")) {
+                        event.toolTip[i] = "§eAlt-click to call!"
+                        return@also
+                    }
+                }
+            }
         }
         if (DevTools.getToggle("nbt") && Keyboard.isKeyDown(46) && GuiScreen.isCtrlKeyDown() && !GuiScreen.isShiftKeyDown() && !GuiScreen.isAltKeyDown()) {
             GuiScreen.setClipboardString(event.itemStack?.tagCompound?.toString())

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -281,6 +281,17 @@ object ItemFeatures {
                         event.isCanceled = true
                     }
                 }
+                if (Skytils.config.mayorVotePerkThreshold > 1 && chestName.startsWith("Election")) {
+                    val mayorColorCode = item.displayName.take(2)
+                    val numPerks = getItemLore(item)
+                        .filter {
+                            it.startsWith(mayorColorCode) && !it.startsWith("$mayorColorCode§")
+                            && !(it.contains(" vote") || it.contains("SPECIAL "))
+                        }
+                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold) {
+                        event.isCanceled = true
+                    }
+                }
             }
         }
     }
@@ -425,6 +436,28 @@ object ItemFeatures {
                     if (event.toolTip[i].contains("click to call!")) {
                         event.toolTip[i] = "§eAlt-click to call!"
                         return@also
+                    }
+                }
+            }
+        }
+        if (Skytils.config.mayorVotePerkThreshold > 1 && event.toolTip.any { it.contains("vote") }) {
+            also {
+                val mayorColorCode = item.displayName.take(2)
+                val numPerks = getItemLore(item)
+                    .filter {
+                        it.startsWith(mayorColorCode) && !it.startsWith("$mayorColorCode§")
+                        && !(it.contains(" vote") || it.contains("SPECIAL "))
+                    }
+                val plural = if (Skytils.config.mayorVotePerkThreshold > 1) "s" else ""
+                if (numPerks.size < Skytils.config.mayorVotePerkThreshold) {
+                    for (i in event.toolTip.indices) {
+                        if (event.toolTip[i].contains("Click to vote for ")) {
+                            event.toolTip[i] = "§eThis candidate has less than ${Skytils.config.mayorVotePerkThreshold} perk$plural!"
+                            return@also
+                        } else if (event.toolTip[i].contains("You voted for this candidate!")) {
+                            event.toolTip[i] = "§ePlease vote for another candidate that has more than ${Skytils.config.mayorVotePerkThreshold} perk$plural."
+                            return@also
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -276,7 +276,7 @@ object ItemFeatures {
                         }
                     }
                 }
-                if (Skytils.config.abiphoneCallPrevention && getItemLore(item).isNotEmpty()) {
+                if (Skytils.config.abiphoneCallPrevention && getItemLore(item).isNotEmpty()) { //keycode 56 and 184 = LMENU and RMENU (ALT) keys respectively
                     if ((getItemLore(item).any { it.contains("click to call!") }) && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))) {
                         event.isCanceled = true
                     }
@@ -285,10 +285,10 @@ object ItemFeatures {
                     val mayorColorCode = item.displayName.take(2)
                     val numPerks = getItemLore(item)
                         .filter {
-                            it.startsWith(mayorColorCode) && !it.startsWith("$mayorColorCode§")
-                            && !(it.contains(" vote") || it.contains("SPECIAL "))
+                            it.startsWith(mayorColorCode) && !it.startsWith("$mayorColorCode§") //count lines that actually contain mayor perks w/o false positives
+                            && !(it.contains(" vote") || it.contains("SPECIAL ")) //ignore non-perk lines that share color code with that of mayor
                         }
-                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold) {
+                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))) {
                         event.isCanceled = true
                     }
                 }
@@ -442,6 +442,7 @@ object ItemFeatures {
         }
         if (Skytils.config.mayorVotePerkThreshold > 1 && event.toolTip.any { it.contains("vote") }) {
             also {
+                val mayorName =item.displayName.stripControlCodes()
                 val mayorColorCode = item.displayName.take(2)
                 val numPerks = getItemLore(item)
                     .filter {
@@ -450,12 +451,14 @@ object ItemFeatures {
                     }
                 val plural = if (Skytils.config.mayorVotePerkThreshold > 1) "s" else ""
                 if (numPerks.size < Skytils.config.mayorVotePerkThreshold) {
-                    for (i in event.toolTip.indices) {
+                    val lessThanMessage = "$mayorName has less than ${Skytils.config.mayorVotePerkThreshold} perk$plural"
+                    for (i in event.toolTip.indices) { //A lot of this can be done with event.toolTip.last(), but with how frequently Hypixel admins can change item tooltips...
                         if (event.toolTip[i].contains("Click to vote for ")) {
-                            event.toolTip[i] = "§eThis candidate has less than ${Skytils.config.mayorVotePerkThreshold} perk$plural!"
+                            event.toolTip[i] = "§e$lessThanMessage!"
+                            event.toolTip.add("§eVote for $mayorName anyway by Alt-clicking.")
                             return@also
                         } else if (event.toolTip[i].contains("You voted for this candidate!")) {
-                            event.toolTip[i] = "§ePlease vote for another candidate that has more than ${Skytils.config.mayorVotePerkThreshold} perk$plural."
+                            event.toolTip[i] = "§eChange your vote; $lessThanMessage."
                             return@also
                         }
                     }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -473,6 +473,16 @@ object ItemFeatures {
                 }
             }
         }
+        if (Skytils.config.wardrobeUnequipPrevent && event.toolTip.any { it.contains(" unequip ") }) {
+            also {
+                for (i in event.toolTip.indices) {
+                    if (event.toolTip[i].contains(" unequip ")) {
+                        event.toolTip[i] = "§eAlt-click to unequip this armor"
+                        return@also
+                    }
+                }
+            }
+        }
         if (DevTools.getToggle("nbt") && Keyboard.isKeyDown(46) && GuiScreen.isCtrlKeyDown() && !GuiScreen.isShiftKeyDown() && !GuiScreen.isAltKeyDown()) {
             GuiScreen.setClipboardString(event.itemStack?.tagCompound?.toString())
         }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -266,6 +266,7 @@ object ItemFeatures {
                 val item = event.slot.stack ?: return
                 val extraAttr = getExtraAttributes(item)
                 val chestName = event.chestName
+                val isAltKeyPressed = (Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))
                 if (Skytils.config.stopClickingNonSalvageable) {
                     if (chestName.startsWith("Salvage") && extraAttr != null) {
                         if (!extraAttr.hasKey("baseStatBoostPercentage") && !item.displayName.contains("Salvage") && !item.displayName.contains(
@@ -277,7 +278,8 @@ object ItemFeatures {
                     }
                 }
                 if (Skytils.config.abiphoneCallPrevention && getItemLore(item).isNotEmpty()) { //keycode 56 and 184 = LMENU and RMENU (ALT) keys respectively
-                    if ((getItemLore(item).any { it.contains("click to call!") }) && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))) {
+                    //i would check for chest name here, but bingo abiphones have this "SuPeR sPeCiAL" `B` variant that i can't be bothered to check for, so enjoy this catch-all conditional below
+                    if ((getItemLore(item).any { it.contains("click to call!") }) && !isAltKeyPressed) {
                         event.isCanceled = true
                     }
                 }
@@ -288,7 +290,13 @@ object ItemFeatures {
                             it.startsWith(mayorColorCode) && !it.startsWith("$mayorColorCode§") //count lines that actually contain mayor perks w/o false positives
                             && !(it.contains(" vote") || it.contains("SPECIAL ")) //ignore non-perk lines that share color code with that of mayor
                         }
-                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold && !(Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))) {
+                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold && !isAltKeyPressed) {
+                        event.isCanceled = true
+                    }
+                }
+                //implement suggestion #2743 by Ownwn — NOTE: does not override NEU's wardrobe keybinds
+                if (Skytils.config.wardrobeUnequipPrevent && getItemLore(item).isNotEmpty() && chestName.startsWith("Wardrobe")) {
+                    if ((item.displayName.contains("Equipped")) && !isAltKeyPressed) {
                         event.isCanceled = true
                     }
                 }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -266,7 +266,7 @@ object ItemFeatures {
                 val item = event.slot.stack ?: return
                 val extraAttr = getExtraAttributes(item)
                 val chestName = event.chestName
-                val isAltKeyPressed = (Keyboard.isKeyDown(56) || Keyboard.isKeyDown(184))
+                val isTabKeyPressed = (Keyboard.isKeyDown(15)) //15 = TAB
                 if (Skytils.config.stopClickingNonSalvageable) {
                     if (chestName.startsWith("Salvage") && extraAttr != null) {
                         if (!extraAttr.hasKey("baseStatBoostPercentage") && !item.displayName.contains("Salvage") && !item.displayName.contains(
@@ -279,7 +279,7 @@ object ItemFeatures {
                 }
                 if (Skytils.config.abiphoneCallPrevention && getItemLore(item).isNotEmpty()) { //keycode 56 and 184 = LMENU and RMENU (ALT) keys respectively
                     //i would check for chest name here, but bingo abiphones have this "SuPeR sPeCiAL" `B` variant that i can't be bothered to check for, so enjoy this catch-all conditional below
-                    if ((getItemLore(item).any { it.contains("click to call!") }) && !isAltKeyPressed) {
+                    if ((getItemLore(item).any { it.contains("click to call!") }) && !isTabKeyPressed) {
                         event.isCanceled = true
                     }
                 }
@@ -290,13 +290,18 @@ object ItemFeatures {
                             it.startsWith(mayorColorCode) && !it.startsWith("$mayorColorCode§") //count lines that actually contain mayor perks w/o false positives
                             && !(it.contains(" vote") || it.contains("SPECIAL ")) //ignore non-perk lines that share color code with that of mayor
                         }
-                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold && !isAltKeyPressed) {
+                    if (numPerks.size < Skytils.config.mayorVotePerkThreshold && !isTabKeyPressed) {
                         event.isCanceled = true
                     }
                 }
                 //implement suggestion #2743 by Ownwn — NOTE: does not override NEU's wardrobe keybinds
                 if (Skytils.config.wardrobeUnequipPrevent && getItemLore(item).isNotEmpty() && chestName.startsWith("Wardrobe")) {
-                    if ((item.displayName.contains("Equipped")) && !isAltKeyPressed) {
+                    if ((item.displayName.contains("Equipped")) && !isTabKeyPressed) {
+                        event.isCanceled = true
+                    }
+                }
+                if (Skytils.config.pickupMinionPrevent && chestName.contains(" Minion ") && !chestName.endsWith(" Recipe") && getItemLore(item).isNotEmpty()) {
+                    if (item.displayName.contains("Pickup Minion") && !isTabKeyPressed) {
                         event.isCanceled = true
                     }
                 }
@@ -442,7 +447,7 @@ object ItemFeatures {
             also {
                 for (i in event.toolTip.indices) {
                     if (event.toolTip[i].contains("click to call!")) {
-                        event.toolTip[i] = "§eAlt-click to call!"
+                        event.toolTip[i] = "§eTab-click to call!"
                         return@also
                     }
                 }
@@ -463,7 +468,7 @@ object ItemFeatures {
                     for (i in event.toolTip.indices) { //A lot of this can be done with event.toolTip.last(), but with how frequently Hypixel admins can change item tooltips...
                         if (event.toolTip[i].contains("Click to vote for ")) {
                             event.toolTip[i] = "§e$lessThanMessage!"
-                            event.toolTip.add("§eVote for $mayorName anyway by Alt-clicking.")
+                            event.toolTip.add("§eVote for $mayorName anyway by Tab-clicking.")
                             return@also
                         } else if (event.toolTip[i].contains("You voted for this candidate!")) {
                             event.toolTip[i] = "§eChange your vote; $lessThanMessage."
@@ -477,7 +482,17 @@ object ItemFeatures {
             also {
                 for (i in event.toolTip.indices) {
                     if (event.toolTip[i].contains(" unequip ")) {
-                        event.toolTip[i] = "§eAlt-click to unequip this armor"
+                        event.toolTip[i] = "§eTab-click to unequip this armor"
+                        return@also
+                    }
+                }
+            }
+        }
+        if (Skytils.config.pickupMinionPrevent && event.toolTip.any { it.contains(" pickup!") }) {
+            also {
+                for (i in event.toolTip.indices) {
+                    if (event.toolTip[i].contains(" pickup!")) {
+                        event.toolTip[i] = "§eTab-click to pickup!"
                         return@also
                     }
                 }


### PR DESCRIPTION
*restores #430. original description below.*
>- Pickup minion
>- Mayor voting
>- Wardrobe unequiping
>- Abiphone calling
>
>TAB key is a bit unorthodox of a key to hold to bypass the preventions, but as a macOS user I don't trust whatever comes out of Ctrl-click (macOS has some system-specifc "ctrl + click = right click" schtick that I'm not a big fan of). I *was* going to use ALT, but Hypixel seems to use that key pretty often as a stand-in for mouse button clicks, and LMETA triggers the Windows start menu, so TAB it is unless if there's better ideas.