### PR TITLE
Force two-decimal precision on terracotta respawn timers

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonFeatures.kt
@@ -32,7 +32,6 @@ import gg.skytils.skytilsmod.features.impl.handlers.MayorInfo
 import gg.skytils.skytilsmod.listeners.DungeonListener
 import gg.skytils.skytilsmod.mixins.transformers.accessors.AccessorEnumDyeColor
 import gg.skytils.skytilsmod.utils.*
-import gg.skytils.skytilsmod.utils.NumberUtil.roundToPrecision
 import gg.skytils.skytilsmod.utils.Utils.equalsOneOf
 import gg.skytils.skytilsmod.utils.graphics.ScreenRenderer
 import gg.skytils.skytilsmod.utils.graphics.SmartFontRenderer
@@ -613,7 +612,7 @@ object DungeonFeatures {
             val diff = it.value - System.currentTimeMillis()
             RenderUtil.drawLabel(
                 it.key.middleVec(),
-                "${(diff / 1000.0).roundToPrecision(2)}s",
+                "${"%.2f".format(diff / 1000.0)}s",
                 Color.WHITE,
                 event.partialTicks,
                 stack


### PR DESCRIPTION
The terracotta respawn timer creates a centered label on each block where a terracotta will respawn. Every tenth of a second, when numbers ended in a 0, the existing code omitted the final digit. This made the label jump around instead of staying in the same place, since it was centered but had a constantly-changing width.

This PR forces the numbers to two decimal places, using [String#format](https://kotlinlang.org/docs/strings.html#string-formatting).

Tested and works fine in floor 6.