### PR TITLE
fix: always show item highlight

### DIFF
--- a/src/main/java/gg/skytils/skytilsmod/mixins/transformers/gui/MixinGuiIngame.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/transformers/gui/MixinGuiIngame.java
@@ -19,6 +19,7 @@
 package gg.skytils.skytilsmod.mixins.transformers.gui;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import gg.skytils.skytilsmod.mixins.hooks.gui.GuiIngameForgeHookKt;
 import gg.skytils.skytilsmod.mixins.hooks.gui.GuiIngameHookKt;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiIngame;
@@ -45,7 +46,7 @@ public abstract class MixinGuiIngame extends Gui {
 
     @ModifyExpressionValue(method = "renderSelectedItem", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/GuiIngame;remainingHighlightTicks:I", opcode = Opcodes.GETFIELD))
     private int alwaysShowItemHighlight(int original) {
-        return GuiIngameHookKt.alwaysShowItemHighlightOptifine(original);
+        return GuiIngameForgeHookKt.alwaysShowItemHighlight(original);
     }
 
     @Inject(method = "setRecordPlaying(Ljava/lang/String;Z)V", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/gg/skytils/skytilsmod/mixins/transformers/gui/MixinGuiIngame.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/transformers/gui/MixinGuiIngame.java
@@ -18,10 +18,12 @@
 
 package gg.skytils.skytilsmod.mixins.transformers.gui;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import gg.skytils.skytilsmod.mixins.hooks.gui.GuiIngameHookKt;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiIngame;
 import net.minecraft.entity.player.EntityPlayer;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -40,6 +42,11 @@ public abstract class MixinGuiIngame extends Gui {
 
     @Shadow
     protected boolean recordIsPlaying;
+
+    @ModifyExpressionValue(method = "renderSelectedItem", at = @At(value = "FIELD", target = "Lnet/minecraft/client/gui/GuiIngame;remainingHighlightTicks:I", opcode = Opcodes.GETFIELD))
+    private int alwaysShowItemHighlight(int original) {
+        return GuiIngameHookKt.alwaysShowItemHighlightOptifine(original);
+    }
 
     @Inject(method = "setRecordPlaying(Ljava/lang/String;Z)V", at = @At("HEAD"), cancellable = true)
     private void onSetActionBar(String message, boolean isPlaying, CallbackInfo ci) {

--- a/src/main/java/gg/skytils/skytilsmod/mixins/transformers/gui/MixinGuiIngameForge.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/transformers/gui/MixinGuiIngameForge.java
@@ -36,7 +36,7 @@ public abstract class MixinGuiIngameForge extends GuiIngame {
         super(mcIn);
     }
 
-    @ModifyExpressionValue(method = "renderToolHightlight", at = @At(value = "FIELD", target = "Lnet/minecraftforge/client/GuiIngameForge;remainingHighlightTicks:I", opcode = Opcodes.GETFIELD, ordinal = 0))
+    @ModifyExpressionValue(method = "renderToolHightlight", at = @At(value = "FIELD", target = "Lnet/minecraftforge/client/GuiIngameForge;remainingHighlightTicks:I", opcode = Opcodes.GETFIELD))
     private int alwaysShowItemHighlight(int original) {
         return GuiIngameForgeHookKt.alwaysShowItemHighlight(original);
     }

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/gui/GuiIngameForgeHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/gui/GuiIngameForgeHook.kt
@@ -27,7 +27,7 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args
 
 
 fun alwaysShowItemHighlight(orig: Int): Int {
-    return if (Skytils.config.alwaysShowItemHighlight && Utils.inSkyblock) 1 else orig
+    return if (Skytils.config.alwaysShowItemHighlight && Utils.inSkyblock) 10 else orig
 }
 
 fun modifyItemHighlightPosition(args: Args, highlightingItemStack: ItemStack) {

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/gui/GuiIngameHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/gui/GuiIngameHook.kt
@@ -31,6 +31,10 @@ var recordPlaying: String? = null
 var recordPlayingUpFor: Int = 0
 var recordIsPlaying: Boolean = false
 
+fun alwaysShowItemHighlightOptifine(orig: Int): Int {
+    return if (Skytils.config.alwaysShowItemHighlight && Utils.inSkyblock) 10 else orig
+}
+
 fun onSetActionBar(message: String, isPlaying: Boolean, ci: CallbackInfo): Boolean {
     val event = SetActionBarEvent(message, isPlaying)
     if (event.postAndCatch()) {

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/gui/GuiIngameHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/gui/GuiIngameHook.kt
@@ -31,10 +31,6 @@ var recordPlaying: String? = null
 var recordPlayingUpFor: Int = 0
 var recordIsPlaying: Boolean = false
 
-fun alwaysShowItemHighlightOptifine(orig: Int): Int {
-    return if (Skytils.config.alwaysShowItemHighlight && Utils.inSkyblock) 10 else orig
-}
-
 fun onSetActionBar(message: String, isPlaying: Boolean, ci: CallbackInfo): Boolean {
     val event = SetActionBarEvent(message, isPlaying)
     if (event.postAndCatch()) {


### PR DESCRIPTION
2 issues: both in line 603
![image](https://github.com/Skytils/SkytilsMod/assets/74718793/0d7fab76-a9c0-4ffe-a84a-c8b9805d306c)
It basically only modified the check in line 595 before, meaning the opacity was 0 * 256 / 10 which is still 0 and stopped it from rendering.
Second issue is that 1 is only barely visible, so 10 is used instead, as that is the max needed basically.