### PR TITLE
Remove: Block Zapper Fatigue Timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ If you have a GitHub account, <b>PLEASE CONSIDER STARRING</b> and forking the re
 - Jerry-chine Gun Sound Hider
 - Show Enchanted Book Abbreviation
 - Show Radioactive Bonus
-- Block Zapper Fatigue Timer
 - Etherwarp Teleport Display
 
 </details>

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2069,16 +2069,6 @@ object Config : Vigilant(
     var pricePaid = false
 
     @Property(
-        type = PropertyType.SWITCH, name = "Block Zapper Fatigue Timer",
-        description = "Displays how long your block zapper is fatigued for.",
-        category = "Miscellaneous", subcategory = "Items",
-        i18nName = "skytils.config.miscellaneous.items.block_zapper_fatigue_timer",
-        i18nCategory = "skytils.config.miscellaneous",
-        i18nSubcategory = "skytils.config.miscellaneous.items"
-    )
-    var blockZapperFatigueTimer = false
-
-    @Property(
         type = PropertyType.SWITCH, name = "Disable Block Animation",
         description = "Removes the block animation on swords.",
         category = "Miscellaneous", subcategory = "Items",

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
@@ -93,8 +93,6 @@ object MiscFeatures {
     var placedEyes = 0
     private var lastGLeaveCommand = 0L
     private var lastCoopAddCommand = 0L
-    private var blockZapperCooldownExpiration = 0L
-    private var blockZapperUses = 0
     private val cheapCoins = setOf(
         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTM4MDcxNzIxY2M1YjRjZDQwNmNlNDMxYTEzZjg2MDgzYTg5NzNlMTA2NGQyZjg4OTc4Njk5MzBlZTZlNTIzNyJ9fX0=",
         "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGZhMDg3ZWI3NmU3Njg3YTgxZTRlZjgxYTdlNjc3MjY0OTk5MGY2MTY3Y2ViMGY3NTBhNGM1ZGViNmM0ZmJhZCJ9fX0=",
@@ -157,33 +155,6 @@ object MiscFeatures {
             golemSpawnTime = System.currentTimeMillis() + 20000
         }
 
-        if (Skytils.config.blockZapperFatigueTimer) {
-            if (formatted.startsWith("§eZapped §a") && formatted.endsWith("§a§lUNDO§r")) {
-                blockZapperCooldownExpiration = 0L
-                blockZapperUses++
-                printDevMessage("$blockZapperUses", "zapper")
-
-                if (blockZapperUses >= 20) {
-                    blockZapperUses = 0
-                    blockZapperCooldownExpiration = System.currentTimeMillis() + 420_000
-                    printDevMessage("$blockZapperCooldownExpiration", "zapper")
-                }
-            }
-            if (unformatted == "Your zapper is temporarily fatigued!") {
-                val duration = (blockZapperCooldownExpiration - System.currentTimeMillis()).milliseconds
-                printDevMessage("$blockZapperUses ${duration.inWholeSeconds}", "zapper")
-                if (duration.isPositive()) {
-                    UChat.chat("$prefix §eThis will expire in${
-                        duration
-                            .toComponents { minutes, seconds, _ -> "${if (minutes > 0) " ${minutes}m " else " "}${seconds}s!" }
-                    }")
-                } else {
-                    blockZapperCooldownExpiration = System.currentTimeMillis() + 420_000
-                    blockZapperUses = 0
-                    printDevMessage("fallback: $blockZapperCooldownExpiration", "zapper")
-                }
-            }
-        }
         if (!Utils.inDungeons) {
             if (Skytils.config.copyDeathToClipboard) {
                 if (formatted.startsWith("§r§c ☠ ")) {

--- a/src/main/resources/assets/skytils/lang/en_US.lang
+++ b/src/main/resources/assets/skytils/lang/en_US.lang
@@ -195,7 +195,6 @@ skytils.config.miscellaneous.fixes.fix_world_time=Fix World Time
 skytils.config.miscellaneous.fixes.prevent_log_spam=Prevent Log Spam
 skytils.config.miscellaneous.fixes.twitch_fix=Twitch Fix
 skytils.config.miscellaneous.items.price_paid=Price Paid
-skytils.config.miscellaneous.items.block_zapper_fatigue_timer=Block Zapper Fatigue Timer
 skytils.config.miscellaneous.items.disable_block_animation=Disable Block Animation
 skytils.config.miscellaneous.items.dropped_item_size=Dropped Item Size
 skytils.config.miscellaneous.items.hide_implosion_particles=Hide Implosion Particles

--- a/src/main/resources/assets/skytils/lang/zh_CN.lang
+++ b/src/main/resources/assets/skytils/lang/zh_CN.lang
@@ -195,7 +195,6 @@ skytils.config.miscellaneous.fixes.fix_world_time=修复世界时间
 skytils.config.miscellaneous.fixes.prevent_log_spam=防止垃圾日志
 skytils.config.miscellaneous.fixes.twitch_fix=Twitch修复
 skytils.config.miscellaneous.items.price_paid=记录支付的价格
-skytils.config.miscellaneous.items.block_zapper_fatigue_timer=Block Zapper损坏恢复倒计时
 skytils.config.miscellaneous.items.disable_block_animation=禁用格挡动画
 skytils.config.miscellaneous.items.dropped_item_size=掉落物品大小
 skytils.config.miscellaneous.items.hide_implosion_particles=隐藏爆炸粒子

--- a/src/main/resources/assets/skytils/lang/zh_TW.lang
+++ b/src/main/resources/assets/skytils/lang/zh_TW.lang
@@ -195,7 +195,6 @@ skytils.config.miscellaneous.fixes.fix_world_time=修復世界時間
 skytils.config.miscellaneous.fixes.prevent_log_spam=防止垃圾日誌
 skytils.config.miscellaneous.fixes.twitch_fix=Twitch修復
 skytils.config.miscellaneous.items.price_paid=記錄支付的價格
-skytils.config.miscellaneous.items.block_zapper_fatigue_timer=Block Zapper損壞恢復倒計時
 skytils.config.miscellaneous.items.disable_block_animation=禁用格擋動畫
 skytils.config.miscellaneous.items.dropped_item_size=掉落物品大小
 skytils.config.miscellaneous.items.hide_implosion_particles=隱藏爆炸粒子


### PR DESCRIPTION
Block Zapper fatigue was removed by Hypixel shortly after the SkyBlock 0.19.9 update.

https://hypixel.net/threads/skyblock-patch-notes-0-19-9-pet-training-and-bestiary-changes.5555803/