### PR TITLE
Corleone Detection Change

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -39,7 +39,6 @@ import gg.skytils.skytilsmod.events.impl.PacketEvent
 import gg.skytils.skytilsmod.features.impl.handlers.MayorInfo
 import gg.skytils.skytilsmod.utils.*
 import gg.skytils.skytilsmod.utils.RenderUtil.highlight
-import gg.skytils.skytilsmod.utils.graphics.SmartFontRenderer
 import gg.skytils.skytilsmod.utils.graphics.colors.ColorFactory
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.client.renderer.GlStateManager
@@ -356,10 +355,11 @@ object MiningFeatures {
     @SubscribeEvent
     fun onRenderLivingPre(event: RenderLivingEvent.Pre<EntityLivingBase?>) {
         if (!Utils.inSkyblock) return
-        if (Skytils.config.crystalHollowWaypoints && event.entity is EntityOtherPlayerMP && event.entity.name == "Team Treasurite" && event.entity.baseMaxHealth == if (MayorInfo.mayorPerks.contains(
-                    "DOUBLE MOBS HP!!!"
-                )
-            ) 2_000_000.0 else 1_000_000.0
+        if (Skytils.config.crystalHollowWaypoints &&
+            event.entity is EntityOtherPlayerMP &&
+            event.entity.name == "Team Treasurite" &&
+            mc.thePlayer.canEntityBeSeen(event.entity) &&
+            event.entity.baseMaxHealth == if (MayorInfo.mayorPerks.contains("DOUBLE MOBS HP!!!")) 2_000_000.0 else 1_000_000.0
         ) {
             waypoints["Corleone"] = event.entity.position
         }


### PR DESCRIPTION
Improved visibility logic for Corleone entity using `canEntityBeSeen`. This prevents the Corleone waypoint from being detected through walls.

(This also takes the wind out of the sails of other developers' arguments that they can incorporate cheats into their tools.)
<details>
<summary>E.g. NwjnAddons</summary>

![image](https://github.com/Skytils/SkytilsMod/assets/24389977/eca39cb4-32fd-40a6-8ca0-170a97666569)

</details>
