### PR TITLE
Fixed item stack copy

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -282,8 +282,7 @@ object MiningFeatures {
         if (!Utils.inSkyblock || event.container !is ContainerChest) return
         if (!event.slot.hasStack) return
         if (Skytils.config.highlightDisabledHOTMPerks && SBInfo.lastOpenContainerName == "Heart of the Mountain") {
-            val item = event.slot.stack
-            if (ItemUtil.getItemLore(item).any { it == "§c§lDISABLED" }) {
+            if (ItemUtil.getItemLore(event.slot.stack).any { it == "§c§lDISABLED" }) {
                 event.slot highlight Color(255, 0, 0)
             }
         }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -280,20 +280,20 @@ object MiningFeatures {
     @SubscribeEvent
     fun onDrawSlot(event: GuiContainerEvent.DrawSlotEvent.Pre) {
         if (!Utils.inSkyblock || event.container !is ContainerChest) return
-        if (event.slot.hasStack) {
+        if (!event.slot.hasStack) return
+        if (Skytils.config.highlightDisabledHOTMPerks && SBInfo.lastOpenContainerName == "Heart of the Mountain") {
             val item = event.slot.stack
-            if (Skytils.config.highlightDisabledHOTMPerks && SBInfo.lastOpenContainerName == "Heart of the Mountain") {
-                if (ItemUtil.getItemLore(item).any { it == "§c§lDISABLED" }) {
-                    event.slot highlight Color(255, 0, 0)
-                }
+            if (ItemUtil.getItemLore(item).any { it == "§c§lDISABLED" }) {
+                event.slot highlight Color(255, 0, 0)
             }
-            if (Skytils.config.highlightCompletedCommissions && SBInfo.lastOpenContainerName.equals("Commissions")) {
-                if (item.displayName.startsWith("§6Commission #") && item.item == Items.writable_book) {
-                    if (ItemUtil.getItemLore(item).any {
-                            it == "§eClick to claim rewards!"
-                        }) {
-                        event.slot highlight Color(255, 0, 0)
-                    }
+        }
+        if (Skytils.config.highlightCompletedCommissions && SBInfo.lastOpenContainerName.equals("Commissions")) {
+            val item = event.slot.stack
+            if (item.displayName.startsWith("§6Commission #") && item.item == Items.writable_book) {
+                if (ItemUtil.getItemLore(item).any {
+                        it == "§eClick to claim rewards!"
+                    }) {
+                    event.slot highlight Color(255, 0, 0)
                 }
             }
         }

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/inventory/SlotHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/inventory/SlotHook.kt
@@ -27,7 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 
 fun markTerminalItems(slot: Slot, cir: CallbackInfoReturnable<ItemStack?>) {
     if (!Utils.inSkyblock) return
-    // TODO check if in dungeon
     val original = slot.inventory.getStackInSlot(slot.slotIndex) ?: return
     if (!original.isItemEnchanted && (SelectAllColorSolver.shouldClick.contains(slot.slotNumber) ||
                 StartsWithSequenceSolver.shouldClick.contains(slot.slotNumber))

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/inventory/SlotHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/inventory/SlotHook.kt
@@ -27,11 +27,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable
 
 fun markTerminalItems(slot: Slot, cir: CallbackInfoReturnable<ItemStack?>) {
     if (!Utils.inSkyblock) return
-    val item: ItemStack = (slot.inventory.getStackInSlot(slot.slotIndex) ?: return).copy()
-    if (!item.isItemEnchanted && (SelectAllColorSolver.shouldClick.contains(slot.slotNumber) || StartsWithSequenceSolver.shouldClick.contains(
-            slot.slotNumber
-        ))
+    // TODO check if in dungeon
+    val original = slot.inventory.getStackInSlot(slot.slotIndex) ?: return
+    if (!original.isItemEnchanted && (SelectAllColorSolver.shouldClick.contains(slot.slotNumber) ||
+                StartsWithSequenceSolver.shouldClick.contains(slot.slotNumber))
     ) {
+        val item = original.copy()
         if (item.tagCompound == null) {
             item.tagCompound = NBTTagCompound()
         }


### PR DESCRIPTION
Fixed calling `ItemStack.copy()` too often unnecessary.

In `MiningFeatures.onDrawSlot` we are calling `val item = event.slot.stack`, even outside the HOTM inventories. This causes the injected  `MixinSlot` to call `markTerminalItems`. In here, we create a copy of the item stack before checking if the slot number is part of `SelectAllColorSolver` or `StartsWithSequenceSolver`.