### PR TITLE
Fix NPE in DemonlordSlayer

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/DemonlordSlayer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/DemonlordSlayer.kt
@@ -193,7 +193,6 @@ class DemonlordSlayer(entity: EntityBlaze) :
                     )
                     thrownEntity = e
                     return@tickTimer
-                    //
                 } else if (totemPos?.let { e.name.matches(SlayerFeatures.totemRegex) && e.getDistanceSq(it) < 9 } == true) {
                     totemEntity = e
                 }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/DemonlordSlayer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/DemonlordSlayer.kt
@@ -193,7 +193,8 @@ class DemonlordSlayer(entity: EntityBlaze) :
                     )
                     thrownEntity = e
                     return@tickTimer
-                } else if (e.name.matches(SlayerFeatures.totemRegex) && e.getDistanceSq(totemPos) < 9) {
+                    //
+                } else if (totemPos?.let { e.name.matches(SlayerFeatures.totemRegex) && e.getDistanceSq(it) < 9 } == true) {
                     totemEntity = e
                 }
             }


### PR DESCRIPTION
`totemPos` can be null in `DemonlordSlayer.entityJoinWorld`.
This PR is just a workaround so that the error does not show up, not investigating how the NPE can occur.
```
java.lang.NullPointerException
	at net.minecraft.entity.Entity.func_174818_b(Entity.java:1126)
	at gg.skytils.skytilsmod.features.impl.slayer.impl.DemonlordSlayer$entityJoinWorld$1$1.invoke(DemonlordSlayer.kt:196)
	at gg.skytils.skytilsmod.features.impl.slayer.impl.DemonlordSlayer$entityJoinWorld$1$1.invoke(DemonlordSlayer.kt:187)
	at gg.skytils.skytilsmod.core.TickKt$tickTask$1$1.invokeSuspend(tick.kt:56)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at gg.skytils.ktx-coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at net.minecraft.util.Util.func_181617_a(Util.java:19)

```