### PR TITLE
Fix trailing parenthasis on skymall reset alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <img alt="discord" src="https://img.shields.io/discord/807302538558308352?color=4166f5&label=discord&style=flat-square" />
   </a>
 </p>
-A Hypixel Skyblock Utilities mod.
+A Hypixel Skyblock Utilities mod.  
 
 <p style="font-size: larger">
 09/15/2023:

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/MiningFeatures.kt
@@ -380,7 +380,7 @@ object MiningFeatures {
             Skytils.config.skymallReminder && SBInfo.mode == SkyblockIsland.DwarvenMines.mode
         ) {
             val message = UMessage("§cSkymall reset ")
-            message.append(UTextComponent("§b[HOTM])").setClick(MCClickEventAction.RUN_COMMAND, "/hotm"))
+            message.append(UTextComponent("§b[HOTM]").setClick(MCClickEventAction.RUN_COMMAND, "/hotm"))
             message.chat()
         }
     }


### PR DESCRIPTION
Fix trailing parenthasis on skymall reset alert

the readme change was to initiate the build as it was disabled when doing initial push