### PR TITLE
Fix Croesus

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonChestProfit.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/DungeonChestProfit.kt
@@ -53,7 +53,7 @@ object DungeonChestProfit {
     private val element = DungeonChestProfitElement()
     private var rerollBypass = false
     private val essenceRegex = Regex("§d(?<type>\\w+) Essence §8x(?<count>\\d+)")
-    private val croesusChestRegex = Regex("^(Master Mode|The)? Catacombs - Floor (IV|V?I{0,3})$")
+    private val croesusChestRegex = Regex("^(Master Mode )?The Catacombs - Flo(or (IV|V?I{0,3}))?$")
 
     @SubscribeEvent
     fun onGUIDrawnEvent(event: GuiContainerEvent.ForegroundDrawnEvent) {
@@ -126,7 +126,7 @@ object DungeonChestProfit {
         val stack = event.slot.stack ?: return
         if (stack.item == Items.skull) {
             val name = stack.displayName
-            if (!(name == "§cThe Catacombs" || name == "§cMaster Mode Catacombs")) return
+            if (!(name == "§cThe Catacombs" || name == "§cMaster Mode The Catacombs")) return
             val lore = ItemUtil.getItemLore(stack)
             event.slot highlight when {
                 lore.any { line -> line == "§aNo more Chests to open!" } -> {


### PR DESCRIPTION
they changed the title of the croesus gui from "Master Mode Catacombs - Floor..." to "Master Mode The Catacombs - Floor..." and also its so long that it kinda cuts off after "Master Mode The Catacombs - Flo" so this like fixes it so it works now without having to click every chest individually

oh yeah idk what the change on line 328 was