### PR TITLE
Fix horrible lag in dungeons

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/listeners/DungeonListener.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/listeners/DungeonListener.kt
@@ -222,10 +222,12 @@ object DungeonListener {
                                     entranceLoc = entrance.mainRoom.z * entrance.mainRoom.x
                                 ))
                                 while (DungeonTimer.dungeonStartTime != -1L) {
-                                    while (outboundRoomQueue.isNotEmpty()) {
-                                        val packet = outboundRoomQueue.poll() ?: continue
-                                        WSClient.sendPacketAsync(packet)
+                                    val packet = outboundRoomQueue.poll()
+                                    if (packet == null) {
+                                        delay(50)
+                                        continue
                                     }
+                                    WSClient.sendPacketAsync(packet)
                                 }
                             }
                         }


### PR DESCRIPTION
While loop without a delay starves CPU time in background inside the coroutine's DefaultDispatcher thread, competing with Client thread and causing horrible lag inside dungeons on machines with low amount of CPU cores (<=4)

Add a delay(50) to fix it.

---

While mainly affecting people with low amount of CPU cores, it will also unnecessarily stall a core and prevent any other tasks from running on that core even on CPUs with lots of cores, just that it's effect on the FPS will be lower.

<details>
  <summary>Screenshots</summary>

Image 1 Htop output without the PR:
![Screenshot from 2024-09-19 16-39-39](https://github.com/user-attachments/assets/332b4e28-a238-44bc-967f-ce39fadbb23f)

Image 2 Htop output with the PR (Default dispatcher is not even in the list when I sort by CPU usage):
![Screenshot from 2024-09-19 17-10-28](https://github.com/user-attachments/assets/3ab0930a-5e04-4961-9275-100fed7720aa)

Image 3 Htop output if i find DefaultDispatcher thread in the list with the PR (Uses 0-1% cpu):
![Screenshot from 2024-09-19 17-09-58](https://github.com/user-attachments/assets/c8d022b6-9028-483d-9706-18a0d98414e3)

Image 4 Spark report without the PR:
![Screenshot_from_2024-09-15_07-45-36](https://github.com/user-attachments/assets/871655fb-6cc5-42f3-afd6-af880225fdbd)
 Explanation: The isNotEmpty in kotlin gets compiled to a negated !isEmpty() call. isEmpty() in ConcurrentLinkedQueue calls first() and returns true if it's not null (source: https://github.com/openjdk/jdk8u/blob/master/jdk/src/share/classes/java/util/concurrent/ConcurrentLinkedQueue.java#L428) inside the while loop. There is no delay in the entire while loop since all methods called (isNotEmpty(), poll(), sendPacketAsync()) are non-blocking instant-finishing methods (poll() just returns null if no element is available - the method that blocks till element is available is take(), but it's only available in BlockingLinkedQueue, not ConcurrentLinkedQueue. An alternative fix was to make it BlockingLinkedQueue and call take(), but using blocking methods like take() inside coroutines would prevent another coroutine from using the shared thread so this fix is more feasible.).
</details>