### PR TITLE
Added smolSelf secret setting

### DIFF
--- a/src/main/java/gg/skytils/skytilsmod/utils/SuperSecretSettings.java
+++ b/src/main/java/gg/skytils/skytilsmod/utils/SuperSecretSettings.java
@@ -44,6 +44,7 @@ public class SuperSecretSettings {
     public static boolean noSychic = false;
     public static boolean palworld = false;
     public static boolean sheepifyRebellion = false;
+    public static boolean smolSelf = false;
     public static boolean smolPeople = false;
     public static boolean tryItAndSee = false;
     public static boolean twilightGiant = false;
@@ -114,6 +115,7 @@ public class SuperSecretSettings {
         noSychic = settings.contains("nosychic");
         palworld = settings.contains("palworld");
         sheepifyRebellion = settings.contains("sheepifyRebellion");
+        smolSelf = settings.contains("smolself");
         smolPeople = settings.contains("smolpeople");
         tryItAndSee = settings.contains("tryItAndSee");
         twilightGiant = settings.contains("twilightGiant");

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/entity/EntityLivingBaseHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/entity/EntityLivingBaseHook.kt
@@ -50,7 +50,7 @@ class EntityLivingBaseHook(val entity: EntityLivingBase) {
     }
 
     val isSmol by lazy {
-        Utils.inSkyblock && entity is EntityPlayer && (SuperSecretSettings.smolPeople || isBreefing)
+        Utils.inSkyblock && (entity is EntityPlayer && (SuperSecretSettings.smolPeople || isBreefing)) || (entity is EntityPlayerSP && SuperSecretSettings.smolSelf)
     }
 
     fun modifyPotionActive(potionId: Int, cir: CallbackInfoReturnable<Boolean>) {

--- a/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/entity/EntityLivingBaseHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/mixins/hooks/entity/EntityLivingBaseHook.kt
@@ -50,7 +50,7 @@ class EntityLivingBaseHook(val entity: EntityLivingBase) {
     }
 
     val isSmol by lazy {
-        Utils.inSkyblock && (entity is EntityPlayer && (SuperSecretSettings.smolPeople || isBreefing)) || (entity is EntityPlayerSP && SuperSecretSettings.smolSelf)
+        Utils.inSkyblock && (entity is EntityPlayer && (SuperSecretSettings.smolPeople || (entity is EntityPlayerSP && SuperSecretSettings.smolSelf) || isBreefing))
     }
 
     fun modifyPotionActive(potionId: Int, cir: CallbackInfoReturnable<Boolean>) {


### PR DESCRIPTION
I (along with some other people I know) have gotten too used to the comfort of the smol people setting when playing in f5 mode mainly for hyperion movement.
What always bugged me was that some mob models also became small with this setting, making it annoying to spot them quickly and fight them, so I made this setting to allow players to have only themselves as a small model while everyone else stays big.