### PR TITLE
fix: update spider's den rain time

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
@@ -28,18 +28,20 @@ import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
  * @link https://github.com/PikaFan123/rain-timer
  */
 object RainTimer {
-    var nextRain = 1727548440000
+    var nextRain = 1727548440000 // Unix-Time of a past rain event start in milliseconds
+    var eventCycleTime = 3600000 // Time between two rain event starts in milliseconds
+    var eventCooldownTime = 2400000 // Time between rain event end and start in milliseconds
 
     init {
         RainTimerGuiElement()
-        while (nextRain < System.currentTimeMillis()) nextRain += 4850000
+        while (nextRain < System.currentTimeMillis()) nextRain += eventCycleTime
     }
 
     class RainTimerGuiElement : GuiElement(name = "Rain Timer", x = 10, y = 10) {
         override fun render() {
             if (Utils.inSkyblock && toggled) {
-                if (nextRain < System.currentTimeMillis()) nextRain += 4850000
-                val remainingRain = ((nextRain - System.currentTimeMillis()) - 3850000) / 1000L
+                if (nextRain < System.currentTimeMillis()) nextRain += eventCycleTime
+                val remainingRain = ((nextRain - System.currentTimeMillis()) - eventCooldownTime) / 1000L
                 if (remainingRain > 0) {
                     fr.drawString(
                         "${remainingRain / 60}:${"%02d".format(remainingRain % 60)}",

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
@@ -28,7 +28,7 @@ import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
  * @link https://github.com/PikaFan123/rain-timer
  */
 object RainTimer {
-    const val nextRain = 1727548500000 // Unix-Time of a past rain event start in milliseconds
+    var nextRain = 1727548500000 // Unix-Time of a past rain event start in milliseconds
     const val eventCycleTime = 3600000 // Time between two rain event starts in milliseconds
     const val eventCooldownTime = 2400000 // Time between rain event end and start in milliseconds
 

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
@@ -28,7 +28,7 @@ import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
  * @link https://github.com/PikaFan123/rain-timer
  */
 object RainTimer {
-    var nextRain = 1727548440000 // Unix-Time of a past rain event start in milliseconds
+    var nextRain = 1727548500000 // Unix-Time of a past rain event start in milliseconds
     var eventCycleTime = 3600000 // Time between two rain event starts in milliseconds
     var eventCooldownTime = 2400000 // Time between rain event end and start in milliseconds
 

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
@@ -28,9 +28,9 @@ import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
  * @link https://github.com/PikaFan123/rain-timer
  */
 object RainTimer {
-    var nextRain = 1727548500000 // Unix-Time of a past rain event start in milliseconds
-    var eventCycleTime = 3600000 // Time between two rain event starts in milliseconds
-    var eventCooldownTime = 2400000 // Time between rain event end and start in milliseconds
+    const val nextRain = 1727548500000 // Unix-Time of a past rain event start in milliseconds
+    const val eventCycleTime = 3600000 // Time between two rain event starts in milliseconds
+    const val eventCooldownTime = 2400000 // Time between rain event end and start in milliseconds
 
     init {
         RainTimerGuiElement()

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/spidersden/RainTimer.kt
@@ -28,7 +28,7 @@ import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
  * @link https://github.com/PikaFan123/rain-timer
  */
 object RainTimer {
-    var nextRain = 1596552707000
+    var nextRain = 1727548440000
 
     init {
         RainTimerGuiElement()


### PR DESCRIPTION
Updated nextRain time used for calculations to now show correct rain times.

Time used:
Unix (in milliseconds): 1727548440000
Human Time: GMT Saturday, September 28, 2024 6:34:00 PM Skyblock Time: Year 375, Late Autumn, Day 19

I was unable to create a succesful build of the Mod to test these changes myselfe, please test it before pushing. I'm new to programming and hope this works like it should.