### PR TITLE
Fix slot number for Perkpocalypse perks in calendar

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/MayorInfo.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/MayorInfo.kt
@@ -106,7 +106,7 @@ object MayorInfo {
         ) return
         if (event.container is ContainerChest) {
             val chestName = event.chestName
-            if (((chestName == "Mayor Jerry" && event.slot.slotNumber == 13) || (chestName == "Calendar and Events" && event.slot.slotNumber == 46)) && event.slot.hasStack) {
+            if (((chestName == "Mayor Jerry" && event.slot.slotNumber == 13) || (chestName == "Calendar and Events" && event.slot.slotNumber == 37)) && event.slot.hasStack) {
                 val lore = ItemUtil.getItemLore(event.slot.stack)
                 if (!lore.contains("§9Perkpocalypse Perks:")) return
                 val endingIn = lore.asReversed().find { it.startsWith("§7Next set of perks in") } ?: return


### PR DESCRIPTION
Fixed Perkpocalypse perks not getting detected from the calendar due to the slot number being wrong.

![Screenshot of calendar, showing mayor in slot 37](https://github.com/user-attachments/assets/52c019bd-8e60-49ef-8d3c-e124ac3e3ac2)
