### PR TITLE
fix: previsited tile state setting

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/catlas/Catlas.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/catlas/Catlas.kt
@@ -86,7 +86,9 @@ object Catlas {
             ScanUtils.getRoomFromPos(mc.thePlayer.position)?.uniqueRoom?.let { unq ->
                 if (unq.state == RoomState.PREVISITED) return@let
                 unq.state = RoomState.PREVISITED
-                unq.tiles.forEach { it.state = RoomState.PREVISITED }
+                DungeonInfo.dungeonList.filter { (it as? Room)?.uniqueRoom == unq && it.state != RoomState.PREVISITED }.forEach {
+                    it.state = RoomState.PREVISITED
+                }
             }
             DungeonListener.team[mc.thePlayer.name]?.mapPlayer?.yaw = mc.thePlayer.rotationYaw
         }


### PR DESCRIPTION
other version didn't work properly
left some room connectors
this is only getting called once per room, so it being a little slower shouldn't matter