### PR TITLE
Improve performance of SmartFontRenderer.drawString

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/utils/graphics/SmartFontRenderer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/utils/graphics/SmartFontRenderer.kt
@@ -20,6 +20,7 @@ package gg.skytils.skytilsmod.utils.graphics
 import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
 import gg.skytils.skytilsmod.utils.graphics.colors.CustomColor
 import gg.skytils.skytilsmod.utils.graphics.colors.MinecraftChatColors
+import gg.skytils.skytilsmod.utils.stripControlCodes
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.renderer.GlStateManager
@@ -54,7 +55,7 @@ class SmartFontRenderer : FontRenderer(
         } else if (customColor === CommonColors.CRITICAL) {
             return drawCritText(text, x, y, alignment, shadow)
         }
-        val drawnText = text.replace("§\\[\\d+\\.?\\d*,\\d+\\.?\\d*,\\d+\\.?\\d*]".toRegex(), "")
+        val drawnText = text.stripControlCodes()
         return when (alignment) {
             TextAlignment.MIDDLE -> drawString(
                 text,

--- a/src/main/kotlin/gg/skytils/skytilsmod/utils/graphics/SmartFontRenderer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/utils/graphics/SmartFontRenderer.kt
@@ -20,7 +20,6 @@ package gg.skytils.skytilsmod.utils.graphics
 import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
 import gg.skytils.skytilsmod.utils.graphics.colors.CustomColor
 import gg.skytils.skytilsmod.utils.graphics.colors.MinecraftChatColors
-import gg.skytils.skytilsmod.utils.stripControlCodes
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.renderer.GlStateManager
@@ -55,11 +54,10 @@ class SmartFontRenderer : FontRenderer(
         } else if (customColor === CommonColors.CRITICAL) {
             return drawCritText(text, x, y, alignment, shadow)
         }
-        val drawnText = text.stripControlCodes()
         return when (alignment) {
             TextAlignment.MIDDLE -> drawString(
                 text,
-                x - getStringWidth(drawnText) / 2.0f,
+                x - getStringWidth(text) / 2.0f,
                 y,
                 customColor,
                 TextAlignment.LEFT_RIGHT,
@@ -67,7 +65,7 @@ class SmartFontRenderer : FontRenderer(
             )
             TextAlignment.RIGHT_LEFT -> drawString(
                 text,
-                x - getStringWidth(drawnText),
+                x - getStringWidth(text),
                 y,
                 customColor,
                 TextAlignment.LEFT_RIGHT,


### PR DESCRIPTION
~~Fixes string width in SmartFontRenderer#drawString.~~ Improves performance in SmartFontRenderer#drawString.

The Regex is supposed to clean out the control codes in the format of &\<code\>, to get the raw string that's actually going to be rendered and use that for getStringWidth calculation.

However, the Regex was wrong and only matches the supposedly RGB codes like &[255,  47, 50], I don't understand what is the point in that so its likely just wrong Regex.

It was also appearing in Spark reports since its used in rendering code, if you had uncapped FPS limit (no VSync), the .toRegex() in Kotlin creates a new Regex every time drawString is called, which is equivalent to Pattern.compile in Java, which is not a free operation in terms of performance.

~~This commit just replaces the regex entirely with String#stripControlCodes, which is a Kotlin extension method provided by Utils.kt in Skytils and is used everywhere else in Skytils for removing control codes.~~

This PR just removes the Regex entirely, because as per my last comment (see https://github.com/Skytils/SkytilsMod/pull/543#issuecomment-2869830290), FontRenderer already handles 0 width color and formatting characters correctly and has special handling for bold formatting code giving extra width to the string, so removing the color codes actually would give incorrect string width.

<details>
<summary>Note for future (not relevant anymore)</summary>
Note: String#stripControlCodes calls UTextComponent.stripFormatting which calls EnumChatFormatting.getTextWithoutFormattingCodes, which still uses Regex to do replacing, but it uses the correct color code pattern and precompiles the pattern in a private static final Pattern field, so it does not call Pattern.compile each time, it just does formattingCodePattern.matcher(text).replaceAll("")

A highly performant version of color code removing without using Regex at all via StringBuilder is implemented [here](https://github.com/hannibal002/SkyHanni/blob/762bd80f1e267571081741283742b42e7d604085/src/main/java/at/hannibal2/skyhanni/utils/StringUtils.kt#L66) in SkyHanni and that can be copied if necessary in the future for even more performance, but that is out of the scope of this PR.
</details>

~~It should both fix the string width being larger than normal due to control codes and improve performance at the same time.~~
It should improve performance.