### PR TITLE
Improve performance of SlayerFeatures.onRenderLivingPre

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
@@ -254,12 +254,12 @@ object SlayerFeatures : CoroutineScope {
 
     @SubscribeEvent
     fun onRenderLivingPre(event: RenderLivingEvent.Pre<EntityLivingBase>) {
-        if (!Utils.inSkyblock || !Skytils.config.slayerBossHitbox) return
+        if (!Utils.inSkyblock || !Skytils.config.slayerBossHitbox || mc.renderManager.isDebugBoundingBox) return
         if (event.entity is EntityArmorStand) {
             val entity = event.entity as EntityArmorStand
             if (!entity.hasCustomName()) return
             val name = entity.displayName.unformattedText
-            if (name.endsWith("§c❤") && !name.endsWith("§e0§c❤") && !mc.renderManager.isDebugBoundingBox) {
+            if (name.endsWith("§c❤") && !name.endsWith("§e0§c❤")) {
                 val (x, y, z) = RenderUtil.fixRenderPos(event.x, event.y, event.z)
                 if (ZOMBIE_MINIBOSSES.any { name.contains(it) } || BLAZE_MINIBOSSES.any { name.contains(it) }) {
                     drawOutlinedBoundingBox(

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
@@ -254,12 +254,12 @@ object SlayerFeatures : CoroutineScope {
 
     @SubscribeEvent
     fun onRenderLivingPre(event: RenderLivingEvent.Pre<EntityLivingBase>) {
-        if (!Utils.inSkyblock) return
+        if (!Utils.inSkyblock || !Skytils.config.slayerBossHitbox) return
         if (event.entity is EntityArmorStand) {
             val entity = event.entity as EntityArmorStand
             if (!entity.hasCustomName()) return
             val name = entity.displayName.unformattedText
-            if (Skytils.config.slayerBossHitbox && name.endsWith("§c❤") && !name.endsWith("§e0§c❤") && !mc.renderManager.isDebugBoundingBox) {
+            if (name.endsWith("§c❤") && !name.endsWith("§e0§c❤") && !mc.renderManager.isDebugBoundingBox) {
                 val (x, y, z) = RenderUtil.fixRenderPos(event.x, event.y, event.z)
                 if (ZOMBIE_MINIBOSSES.any { name.contains(it) } || BLAZE_MINIBOSSES.any { name.contains(it) }) {
                     drawOutlinedBoundingBox(


### PR DESCRIPTION
Avoids instanceof, cast, hasCustomName, getDisplayName, getUnformattedText calls if the feature was not enabled in the first place.

Not sure if any neglible performance gains (there is some because calling hasCustomName or getting displayName calls DataWatcher which has ReentrantReadWriteLock), but it would be bad practice to call methods and assign variables just to do a late if check and exit the method. Moving the config check up after inSkyblock seems like a better practice here.