### PR TITLE
fix: coremod version warning

### DIFF
--- a/src/main/java/gg/skytils/skytilsmod/tweaker/SkytilsLoadingPlugin.java
+++ b/src/main/java/gg/skytils/skytilsmod/tweaker/SkytilsLoadingPlugin.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import static gg.skytils.skytilsmod.tweaker.TweakerUtil.exit;
 import static gg.skytils.skytilsmod.tweaker.TweakerUtil.showMessage;
 
+@IFMLLoadingPlugin.MCVersion("1.8.9")
 @IFMLLoadingPlugin.Name("Skytils On Top")
 @IFMLLoadingPlugin.SortingIndex(69)
 public class SkytilsLoadingPlugin implements IFMLLoadingPlugin {


### PR DESCRIPTION
Fixes this coremod version warning:
[main/WARN]: The coremod gg.skytils.skytilsmod.tweaker.SkytilsLoadingPlugin does not have a MCVersion annotation, it may cause issues with this version of Minecraft

which is printed on every startup and misredirects users having irrelevant issues with Skytils that do not know better to assume it's caused by it (as the warning message says it may cause issues with this version of Minecraft).

While many mods print this warning, many also use 1.8.9 as the requested version correctly. Unless you are supporting multiple versions in 1 JAR, adding 1.8.9 version check has no downsides. Users are expected to use 1.8.9 Forge latest build anyways - if they are using 1.8.8 or something weird, this will cause the mod to be not loaded at all and fail early, which is a good thing IMO.

Here's logs from some other mods that request version 1.8.9 correctly:
[main/DEBUG]: The coremod club.sk1er.patcher.tweaker.PatcherTweaker requested minecraft version 1.8.9 and minecraft is 1.8.9. It will be loaded.
[main/DEBUG]: The coremod codes.biscuit.skyblockaddons.tweaker.SkyblockAddonsLoadingPlugin requested minecraft version 1.8.9 and minecraft is 1.8.9. It will be loaded.

Skytils should do the same.

<details>
<summary>Why this has no downsides</summary>
If any efforts to port the mod to latest version arises in the future (with the Foraging update said to be latest version only), you might argue that this change would have to be reverted - but latest version Skytils would entirely be a new project or target Fabric instead of Forge, as that's the de-facto standard mod API for latest versions, and Fabric would not respect the Forge Mod Loader (FML)'s MCVersion annotation anyways in that case.

---

As for supporting multiiple versions with Forge, just to give an example, as you might know, Patcher supports multiple MC Versions, but each JAR has the MCVersion annotation set to the version they are targeting, and the downloads for each version along with their JARs, are different, even though the same repo builds all of the JARs with Gradle. As such, adding the MCVersion annotation does not prevent multi-version support.

TL;DR is that adding this annotation has basically no downside and the upside is 1 less warning message and stricter checking of the targeted version in runtime, and less confused users thinking this message causes any real issues.
</details>