### PR TITLE
fix: wrong entity error spam

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
@@ -53,7 +53,7 @@ import gg.skytils.skytilsmod.utils.graphics.colors.CommonColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import net.minecraft.block.BlockBeacon
 import net.minecraft.client.entity.EntityOtherPlayerMP
@@ -339,9 +339,10 @@ object SlayerFeatures : CoroutineScope {
             ) {
                 slayer?.run {
                     launch {
-                        val (n, t) = detectSlayerEntities().first()
-                        nameEntity = n
-                        timerEntity = t
+                        detectSlayerEntities().firstOrNull()?.let { (n, t) ->
+                            nameEntity = n
+                            timerEntity = t
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/base/Slayer.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/base/Slayer.kt
@@ -24,7 +24,7 @@ import gg.skytils.skytilsmod.features.impl.slayer.SlayerFeatures
 import gg.skytils.skytilsmod.features.impl.slayer.impl.DemonlordSlayer
 import gg.skytils.skytilsmod.utils.baseMaxHealth
 import gg.skytils.skytilsmod.utils.printDevMessage
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import net.minecraft.entity.Entity
 import net.minecraft.entity.EntityLivingBase
@@ -53,9 +53,10 @@ open class Slayer<T : EntityLivingBase>(
 
     init {
         SlayerFeatures.launch {
-            val (n, t) = detectSlayerEntities().first()
-            nameEntity = n
-            timerEntity = t
+            detectSlayerEntities().firstOrNull()?.let { (n, t) ->
+                nameEntity = n
+                timerEntity = t
+            }
         }
     }
 
@@ -111,7 +112,7 @@ open class Slayer<T : EntityLivingBase>(
                     "slayer"
                 )
                 SlayerFeatures.slayer = null
-                throw Exception("Wrong entity!")
+                return@tickTask null
             }
         }
     open fun tick(event: TickEvent.ClientTickEvent) {}


### PR DESCRIPTION
When doing slayers, my logs were filled with thousands of Wrong entity! errors, bloating my logs folder and log sizes and making it harder to find real important exceptions. I asked about this by creating a [discussion](https://discord.com/channels/807302538558308352/1323888819229036585) in Skytils Discord which did not receive much input but we could not find the root cause of the error in the end (though I did close to zero debugging as just removing the exception seemed to fix the errors without breaking any slayer features) and I had the changes in my local Skytils build for months and had no issues, so I decided to finally upstream the changes for everyone to benefit.

Note that despite the error, all slayer features kept working fine.

There's already a printDevMessage above the original exception, so removing the exception does not cost anything in terms of debugging. A simple search of what the printDevMessage prints would already get us to the exact line in this file. Keep in mind that creating exceptions are not free in terms of performance and they have to generate a stack trace in addition to the exception object itself.

detectSlayerEntities was modified to be able return null and usages of detectSlayerEntities were modified to handle null return value gracefully to remove the throwing of the exception. Another alternative is to return a pair of 2 null values but creating unnecessary objects should be avoided.