### PR TITLE
perf: Improve condition ordering

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/MiscFeatures.kt
@@ -205,7 +205,7 @@ object MiscFeatures {
         if (!Utils.inSkyblock) return
         if (Skytils.config.bossBarFix && event.entity is IBossDisplayData && event.entity.isInvisible && event.entity.hasCustomName()) {
             event.result = Event.Result.ALLOW
-        } else if (Skytils.config.hideDyingMobs && event.entity is EntityLivingBase && (event.entity.health <= 0 || event.entity.isDead)) {
+        } else if (Skytils.config.hideDyingMobs && event.entity is EntityLivingBase && (event.entity.isDead || event.entity.health <= 0)) {
             event.isCanceled = true
         } else if (event.entity is EntityFallingBlock) {
             val entity = event.entity

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/RandomStuff.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/RandomStuff.kt
@@ -43,7 +43,7 @@ object RandomStuff {
     fun onCheckRenderEvent(event: CheckRenderEntityEvent<*>) {
         if (!Skytils.config.randomStuff || !Utils.inSkyblock) return
         event.apply {
-            if (entity.isInvisible && DungeonTimer.phase1ClearTime != -1L && DungeonTimer.bossClearTime == -1L && entity is EntityArmorStand) {
+            if (DungeonTimer.phase1ClearTime != -1L && DungeonTimer.bossClearTime == -1L && entity is EntityArmorStand && entity.isInvisible) {
                 val nn = entity.inventory.filterNotNull()
                 if (nn.size != 1) return
                 if (nn.first().item !is ItemBlock) return


### PR DESCRIPTION
Entity.health in kotlin is a property access and is translated to Entity.getHealth method call in runtime. The Entity.getHealth method calls DataWatcher, which uses ReentrantReadWriteLock, hence the call is not free and the health has to be queried. Entity.isDead is a real field, thus a simple field read.

It's better to only query the health if isDead is false.

As per the isInvisible - the same thing, it's actually a method call when compiled, and it calls DataWatcher to query the invisibility status just like getHealth. Instead of going through DataWatcher and ReentrantReadWriteLock we are checking the other conditions first, which are simple long comparisions and an instanceof check. This way we are never calling Entity#isInvisible for non-armorstand entities and when Phase 1 / Boss are cleared (clearTime == -1L).