### PR TITLE
fix: ice fill solver rendering in boss if unfinished

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/IceFillSolver.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/dungeons/solvers/IceFillSolver.kt
@@ -27,6 +27,7 @@ import gg.skytils.skytilsmod.utils.RenderUtil
 import gg.skytils.skytilsmod.utils.SuperSecretSettings
 import gg.skytils.skytilsmod.utils.Utils
 import gg.skytils.skytilsmod.utils.ifNull
+import gg.skytils.skytilsmod.features.impl.dungeons.DungeonTimer
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.minecraft.client.renderer.GlStateManager
@@ -127,7 +128,7 @@ object IceFillSolver {
 
     @SubscribeEvent
     fun onWorldRender(event: RenderWorldLastEvent) {
-        if (!Utils.inDungeons || !Skytils.config.iceFillSolver || "Ice Fill" !in DungeonListener.incompletePuzzles) return
+        if (!Skytils.config.iceFillSolver || !Utils.inDungeons || DungeonTimer.bossEntryTime != -1L || "Ice Fill" !in DungeonListener.incompletePuzzles) return
         val (three, five, seven) = puzzles ?: return
         val matrixStack = UMatrixStack.Compat.get()
         three.draw(matrixStack, event.partialTicks)


### PR DESCRIPTION
"Ice Fill" !in DungeonListener.incompletePuzzles hides it correctly once the puzzle is finished, but if the puzzle was not finished, when you go to the boss it will still be rendered. Adds a new condition to the existing if to ensure bossEntryTime is -1L, meaning boss has not been entered yet, to render the solver.

Also moves config check before inDungeons check (all other checks) as its a simple boolean check and the field only changes if the user changes the option. This for consistency and assumes no other checks are performed if the feature was toggled off.

Ideally, we'd want to only render the solver while inside the ice fill room, and remove the existing inDungeons check, and the bossEntryTime check the PR adds (since you would not be on boss if your in the room, and you'd be in dungeons if you are on the room. The incompletePuzzles check can be kept to hide the solver once the puzzle finishes even if your in the room). This PR does not fix the solver rendering when you are outside the room. In my opinion that should also be fixed via a hook to catlas or something, but I do not know how to do that and ensure it works even if you have catlas disabled.
If anyone is able to do that, this PR can be closed.