### PR TITLE
fix: null cannot be cast to non-null type AbstractClientPlayer

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/listeners/DungeonListener.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/listeners/DungeonListener.kt
@@ -356,7 +356,7 @@ object DungeonListener {
 
                     teammate.player = mc.theWorld.playerEntities.find {
                         it.name == teammate.playerName && it.uniqueID.version() == 4
-                    } as AbstractClientPlayer
+                    } as AbstractClientPlayer?
 
                     old?.locationSkin?.let { teammate.skin = it }
 

--- a/src/main/kotlin/gg/skytils/skytilsmod/listeners/DungeonListener.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/listeners/DungeonListener.kt
@@ -356,7 +356,7 @@ object DungeonListener {
 
                     teammate.player = mc.theWorld.playerEntities.find {
                         it.name == teammate.playerName && it.uniqueID.version() == 4
-                    } as AbstractClientPlayer?
+                    } as? AbstractClientPlayer
 
                     old?.locationSkin?.let { teammate.skin = it }
 


### PR DESCRIPTION
Fixes regression introduced in commit 44d836d at dev branch (not present in any release yet)

Happens a single time but every time when someone dies.

Error log:
```
[15:09:51] [Client thread/ERROR]: Exception caught during firing event MainReceivePacketEvent(handler=net.minecraft.client.network.NetHandlerPlayClient@1844043a, packet=S38PacketPlayerListItem{action=UPDATE_DISPLAY_NAME, entries=[AddPlayerData{latency=0, gameMode=null, profile=com.mojang.authlib.GameProfile@6901af28[id=da83a409-9c85-24b7-b627-61d43f537c21,name=<null>,properties={},legacy=false], displayName={"italic":false,"extra":[{"color":"dark_gray","text":"["},{"color":"blue","text":"301"},{"color":"dark_gray","text":"] "},{"color":"green","text":"Birbgod25 "},{"color":"gray","text":"α "},{"color":"white","text":"("},{"color":"light_purple","text":""},{"color":"red","text":"DEAD"},{"color":"white","text":")"}],"text":""}}]}):
java.lang.NullPointerException: null cannot be cast to non-null type net.minecraft.client.entity.AbstractClientPlayer
	at gg.skytils.skytilsmod.listeners.DungeonListener.onPacket(DungeonListener.kt:349) ~[DungeonListener.class:?]
```