### PR TITLE
refactor: time parsing

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/utils/SBInfo.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/utils/SBInfo.kt
@@ -36,7 +36,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientDisconnectionFromServerEvent
 import java.text.ParseException
-import java.text.SimpleDateFormat
+import org.apache.commons.lang3.time.FastDateFormat
 import java.util.*
 
 /**
@@ -62,6 +62,8 @@ object SBInfo {
     @JvmField
     var lastOpenContainerName: String? = null
     private val junkRegex = Regex("[^\u0020-\u0127û]")
+
+    private val parseFormat = FastDateFormat.getInstance("hh:mm a", Locale.ROOT)
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun onGuiOpen(event: GuiOpenEvent) {
@@ -117,7 +119,6 @@ object SBInfo {
                     time = matcher.groupValues[0].stripControlCodes().trim()
                     try {
                         val timeSpace = time.replace("am", " am").replace("pm", " pm")
-                        val parseFormat = SimpleDateFormat("hh:mm a")
                         currentTimeDate = parseFormat.parse(timeSpace)
                     } catch (_: ParseException) {
                     }


### PR DESCRIPTION
- Use FastDateFormat from Apache Commons Lang3 instead of Java 8 SimpleDateFormat. This better as Apache's version is faster and thread-safe.

- Store the date format instance instead of recreating it everytime

- Use Locale.ROOT instead of using system locale to ensure mod code works with all locales.

Tested in-game and works fine, currentTimeDate is set correctly, no ParseException thrown (removed ignoring of the exception when testing, but going to keep it in the PR just in case)