### PR TITLE
Fix Prevent Placing Weapons and add Gemstone Gauntlet

### DIFF
--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2281,7 +2281,7 @@ object Config : Vigilant(
 
     @Property(
         type = PropertyType.SWITCH, name = "Prevent Placing Weapons",
-        description = "Stops the game from trying to place the Flower of Truth, Moody Grappleshot, Spirit Sceptre, Pumpkin Launcher and Weird Tuba items.",
+        description = "Stops the game from trying to place the Flower of Truth, Moody Grappleshot, Spirit Sceptre, Pumpkin Launcher, Weird Tuba, and Gemstone Gauntlet items.",
         category = "Miscellaneous", subcategory = "Items",
         i18nName = "skytils.config.miscellaneous.items.prevent_placing_weapons",
         i18nCategory = "skytils.config.miscellaneous",

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -96,6 +96,7 @@ import net.minecraft.world.BlockStateRaycastContext
 import java.awt.Color
 import java.time.Instant
 import java.util.Optional
+import java.util.WeakHashMap
 import kotlin.jvm.optionals.getOrDefault
 import kotlin.jvm.optionals.getOrNull
 import kotlin.math.pow
@@ -587,13 +588,19 @@ object ItemFeatures : EventSubscriber {
         "(Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_3965;)Lnet/minecraft/class_1269;"
     )
 
+    private val interactableBlockCache = WeakHashMap<Class<out Block>, Boolean>()
+
     private fun isInteractable(block: Block): Boolean {
         if (Utils.inDungeons && (block === Blocks.COAL_BLOCK || block === Blocks.RED_TERRACOTTA)) {
             return true
         }
 
+        val clazz = block.javaClass
+
         // If the block has its own onUse method that overrides the one in AbstractBlock, it is interactable
-        return block.javaClass.declaredMethods.any { it.name == onUseMethodName }
+        return interactableBlockCache.getOrPut(clazz) {
+            clazz.declaredMethods.any { it.name == onUseMethodName }
+        }
     }
 
     fun onRenderItemOverlayPost(event: GuiContainerPostDrawSlotEvent) {

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -72,6 +72,8 @@ import gg.skytils.skytilsmod.core.structure.v2.HudElement
 import gg.skytils.skytilsmod.gui.layout.text
 import gg.skytils.skytilsmod.utils.multiplatform.textComponent
 import gg.skytils.skytilsmod.utils.rendering.DrawHelper
+import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.block.Block
 import net.minecraft.entity.projectile.FishingBobberEntity
 import net.minecraft.block.Blocks
 import net.minecraft.client.font.TextRenderer
@@ -571,11 +573,27 @@ object ItemFeatures : EventSubscriber {
             ))
         ) {
             val block = mc.world?.getBlockState(event.pos) ?: return
-            // TODO: verify this works as intended
-            if (!block.block.javaClass.run { getMethod("onUse").declaringClass == this } || Utils.inDungeons && (block.block === Blocks.COAL_BLOCK || block.block === Blocks.RED_TERRACOTTA)) {
+            if (!isInteractable(block.block)) {
                 event.cancelled = true
             }
         }
+    }
+
+    // In Yarn mappings, this is AbstractBlock#onUse
+    private val onUseMethodName = FabricLoader.getInstance().mappingResolver.mapMethodName(
+        "intermediary",
+        "net.minecraft.class_4970",
+        "method_55766",
+        "(Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_3965;)Lnet/minecraft/class_1269;"
+    )
+
+    private fun isInteractable(block: Block): Boolean {
+        if (Utils.inDungeons && (block === Blocks.COAL_BLOCK || block === Blocks.RED_TERRACOTTA)) {
+            return true
+        }
+
+        // If the block has its own onUse method that overrides the one in AbstractBlock, it is interactable
+        return block.javaClass.methods.find { it.name == onUseMethodName }?.declaringClass == block.javaClass
     }
 
     fun onRenderItemOverlayPost(event: GuiContainerPostDrawSlotEvent) {

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -566,7 +566,8 @@ object ItemFeatures : EventSubscriber {
                 "WEIRD_TUBA",
                 "WEIRDER_TUBA",
                 "PUMPKIN_LAUNCHER",
-                "FIRE_FREEZE_STAFF"
+                "FIRE_FREEZE_STAFF",
+                "GEMSTONE_GAUNTLET"
             ))
         ) {
             val block = mc.world?.getBlockState(event.pos) ?: return

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/ItemFeatures.kt
@@ -593,7 +593,7 @@ object ItemFeatures : EventSubscriber {
         }
 
         // If the block has its own onUse method that overrides the one in AbstractBlock, it is interactable
-        return block.javaClass.methods.find { it.name == onUseMethodName }?.declaringClass == block.javaClass
+        return block.javaClass.declaredMethods.any { it.name == onUseMethodName }
     }
 
     fun onRenderItemOverlayPost(event: GuiContainerPostDrawSlotEvent) {


### PR DESCRIPTION
This PR fixes the "Prevent Placing Weapons" setting and adds the Gemstone Gauntlet to the list of supported items.

I'm using mapMethodName because the `AbstractBlock#onUse` method name is transformed into an intermediary name when building for a non-development environment, but the hardcoded string isn't automatically transformed. It's recommended [in the Fabric docs](https://wiki.fabricmc.net/tutorial:reflection#remapping), and I found [the same trick being used](https://github.com/AzureAaron/aaron-mod/blob/5ebcdad3ddc2199cf67b7b3ff27791f8cae37e27/src/main/java/net/azureaaron/mod/mixins/MusicTrackerMixin.java#L20) in Aaron's Mod.

I've confirmed that this works in 1.21.5. Does 1.8 still need to be supported? It looks like the GitHub Actions workflow only builds 1.21.5 on the 2.x branch, so I assumed not.

Also, this doesn't work when shift right-clicking on a chest. Was it like that in 1.8? Do you think it's possible and worth the time to fix that?