### PR TITLE
Fix: Use backgroundScreen instead of erroring when casting

### DIFF
--- a/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/accessors/AccessorPopupBackground.java
+++ b/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/accessors/AccessorPopupBackground.java
@@ -1,0 +1,30 @@
+/*
+ * Skytils - Hypixel Skyblock Quality of Life Mod
+ * Copyright (C) 2020-2025 Skytils
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package gg.skytils.skytilsmod.mixins.transformers.accessors;
+
+import net.minecraft.client.gui.screen.PopupScreen;
+import net.minecraft.client.gui.screen.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(PopupScreen.class)
+public interface AccessorPopupBackground {
+    @Accessor("backgroundScreen")
+    Screen getUnderlyingScreen();
+}

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -74,10 +74,9 @@ object DrawHelper {
     fun setupContainerScreenTransformations(matrices: UMatrixStack, aboveItems: Boolean = false) {
         var currentScreen = mc.currentScreen
         if (currentScreen is PopupScreen) {
-            currentScreen = (
-                    currentScreen as? AccessorPopupBackground                                        // Cast to AccessorPopupBackground
-                        ?: error("Current PopupScreen does not implement AccessorPopupBackground")   // Error upon fail
-                    ).underlyingScreen                                                               // Grab backgroundScreen if casting succeeded
+            val accessor = currentScreen as? AccessorPopupBackground
+                ?: error("Current PopupScreen does not implement AccessorPopupBackground")
+            currentScreen = accessor.underlyingScreen
         }
         val screen = currentScreen as? AccessorGuiContainer ?: error("Current ${currentScreen?.javaClass?.simpleName ?: "screen"} does not implement AccessorGuiContainer")
         matrices.translate(screen.guiLeft.toFloat(), screen.guiTop.toFloat(), 0f)

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -73,7 +73,7 @@ object DrawHelper {
      */
     fun setupContainerScreenTransformations(matrices: UMatrixStack, aboveItems: Boolean = false) {
         var currentScreen = mc.currentScreen
-        if (currentScreen is PopupScreen) {
+        while (currentScreen is PopupScreen) {
             val accessor = currentScreen as? AccessorPopupBackground
                 ?: error("Current PopupScreen does not implement AccessorPopupBackground")
             currentScreen = accessor.underlyingScreen

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -73,7 +73,12 @@ object DrawHelper {
      */
     fun setupContainerScreenTransformations(matrices: UMatrixStack, aboveItems: Boolean = false) {
         var currentScreen = mc.currentScreen
-        if (currentScreen is PopupScreen) { currentScreen = (currentScreen as? AccessorPopupBackground ?: error("Current PopupScreen does not implement AccessorPopupBackground")).underlyingScreen }
+        if (currentScreen is PopupScreen) {
+            currentScreen = (
+                    currentScreen as? AccessorPopupBackground                                        // Cast to AccessorPopupBackground
+                        ?: error("Current PopupScreen does not implement AccessorPopupBackground")   // Error upon fail
+                    ).underlyingScreen                                                               // Grab backgroundScreen if casting succeeded
+        }
         val screen = currentScreen as? AccessorGuiContainer ?: error("Current ${currentScreen?.javaClass?.simpleName ?: "screen"} does not implement AccessorGuiContainer")
         matrices.translate(screen.guiLeft.toFloat(), screen.guiTop.toFloat(), 0f)
         if (aboveItems) {

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -18,14 +18,15 @@
 
 package gg.skytils.skytilsmod.utils.rendering
 
-import com.mojang.blaze3d.systems.RenderSystem
 import gg.essential.universal.UGraphics
 import gg.essential.universal.UMatrixStack
 import gg.essential.universal.render.URenderPipeline
 import gg.essential.universal.vertex.UBufferBuilder
 import gg.skytils.skytilsmod.Skytils.mc
 import gg.skytils.skytilsmod.mixins.transformers.accessors.AccessorGuiContainer
+import gg.skytils.skytilsmod.mixins.transformers.accessors.AccessorPopupBackground
 import net.minecraft.client.font.TextRenderer
+import net.minecraft.client.gui.screen.PopupScreen
 import net.minecraft.client.render.OverlayTexture
 import net.minecraft.client.texture.GlTexture
 import net.minecraft.item.ItemDisplayContext
@@ -71,7 +72,9 @@ object DrawHelper {
      * @param aboveItems If true, the Z-level will be set to render above items.
      */
     fun setupContainerScreenTransformations(matrices: UMatrixStack, aboveItems: Boolean = false) {
-        val screen = mc.currentScreen as? AccessorGuiContainer ?: error("Current screen does not implement AccessorGuiContainer")
+        var currentScreen = mc.currentScreen
+        if (currentScreen is PopupScreen) { currentScreen = (currentScreen as? AccessorPopupBackground ?: error("Current PopupScreen does not implement AccessorPopupBackground")).underlyingScreen }
+        val screen = currentScreen as? AccessorGuiContainer ?: error("Current ${currentScreen?.javaClass?.simpleName ?: "screen"} does not implement AccessorGuiContainer")
         matrices.translate(screen.guiLeft.toFloat(), screen.guiTop.toFloat(), 0f)
         if (aboveItems) {
             matrices.translate(0f, 0f, 100f + 150f + 1f)

--- a/mod/src/main/resources/mixins.skytils.json
+++ b/mod/src/main/resources/mixins.skytils.json
@@ -105,6 +105,7 @@
   "client": [
     "accessors.AccessorMultiplayerServerListWidget",
     "accessors.AccessorNetHandlerPlayClient",
+    "accessors.AccessorPopupBackground",
     "events.MixinGuiIngame",
     "events.MixinNetHandlerPlayClient",
     "events.MixinNetworkManager",


### PR DESCRIPTION
This is kind of also a Skyblocker compat because it makes the bug easier to find.

If a `HandledScreen` makes a PopupScreen, the code would error over and over again. Now, it instead uses `AccessorPopupBackground` to get the `backgroundScreen` and attempts to use it instead.

I also removed an unused import and added more clarity to the error message.