### PR TITLE
fix: fov drifting (waypoint blocks)

### DIFF
--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -55,7 +55,7 @@ object DrawHelper {
      */
     fun cameraRotation(matrices: UMatrixStack) {
         //#if MC>12000
-        matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()).mul(70f/mc.options.fov.value.coerceAtLeast(1))
+        matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()).mul(70f/mc.options.fov.value.coerceAtLeast(1)))
         //#else
         //$$matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()))
         //#endif

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -54,7 +54,7 @@ object DrawHelper {
      */
     fun cameraRotation(matrices: UMatrixStack) {
         //#if MC>12000
-        matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()).mul(70f/mc.options.fov.value))
+        matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()).mul(70f/mc.options.fov.value.coerceAtLeast(1))
         //#else
         //$$matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()))
         //#endif

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -53,7 +53,11 @@ object DrawHelper {
      * This is useful for rendering things in world space, as it will negate the camera rotation.
      */
     fun cameraRotation(matrices: UMatrixStack) {
-        matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()))
+        //#if MC>12000
+        matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()).mul(70f/mc.options.fov.value))
+        //#else
+        //$$matrices.multiply(mc.gameRenderer.camera.rotation.conjugate(Quaternionf()))
+        //#endif
     }
 
     /**
@@ -223,9 +227,9 @@ object DrawHelper {
     fun drawNametag(matrices: UMatrixStack, text: String, x: Double, y: Double, z: Double, shadow: Boolean = true, scale: Float = 1f, background: Boolean = true, throughWalls: Boolean = false) {
         matrices.push()
         matrices.translate(x, y + 0.5, z)
-        matrices.multiply(mc.entityRenderDispatcher.rotation)
+        matrices.multiply(mc.gameRenderer.camera.rotation)
+        // TODO: fix fov drifting issues for nametags
         matrices.scale(0.025f, -0.025f, 0.025f)
-
         matrices.scale(scale, scale, scale)
         val centerPos = UGraphics.getStringWidth(text) / -2f
         val backgroundColor = if (!background) 0 else (mc.options.getTextBackgroundOpacity(0.25f) * 255).toInt() shl 24

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/rendering/DrawHelper.kt
@@ -234,7 +234,7 @@ object DrawHelper {
     fun drawNametag(matrices: UMatrixStack, text: String, x: Double, y: Double, z: Double, shadow: Boolean = true, scale: Float = 1f, background: Boolean = true, throughWalls: Boolean = false) {
         matrices.push()
         matrices.translate(x, y + 0.5, z)
-        matrices.multiply(mc.gameRenderer.camera.rotation)
+matrices.multiply(mc.entityRenderDispatcher.rotation)
         // TODO: fix fov drifting issues for nametags
         matrices.scale(0.025f, -0.025f, 0.025f)
         matrices.scale(scale, scale, scale)


### PR DESCRIPTION
fixed waypoint block offsetting because of fov not normalized (70)
it would affect and prob fix (or break) other renders that use `setupCameraTransformations()` but those do not work currently lol

couldnt figure out how to fix the nametags im just throwing rocks at a wall atp
only solution i have is just brute force calculating offset but that isnt great