### PR TITLE
Fix: Coroutine Leak

### DIFF
--- a/events/src/main/kotlin/gg/skytils/event/events.kt
+++ b/events/src/main/kotlin/gg/skytils/event/events.kt
@@ -45,8 +45,11 @@ inline fun <reified T : Event> on(priority: EventPriority = EventPriority.Normal
 
 suspend inline fun <reified T : Event> await(priority: EventPriority = EventPriority.Normal) =
     suspendCancellableCoroutine { coroutine ->
-        val deregister = priority.subscribe<T> { event ->
+        lateinit var deregister: () -> Boolean
+
+        deregister = priority.subscribe<T> { event ->
             if (coroutine.isActive) {
+                deregister()
                 coroutine.resume(event)
             }
         }

--- a/events/src/main/kotlin/gg/skytils/event/events.kt
+++ b/events/src/main/kotlin/gg/skytils/event/events.kt
@@ -20,6 +20,7 @@ package gg.skytils.event
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 
 suspend fun <T : Event> post(event: T) =
@@ -45,16 +46,19 @@ inline fun <reified T : Event> on(priority: EventPriority = EventPriority.Normal
 
 suspend inline fun <reified T : Event> await(priority: EventPriority = EventPriority.Normal) =
     suspendCancellableCoroutine { coroutine ->
+        val resumed = AtomicBoolean(false)
         lateinit var deregister: () -> Boolean
 
         deregister = priority.subscribe<T> { event ->
-            if (coroutine.isActive) {
+            if (resumed.compareAndSet(false, true)) {
                 deregister()
                 coroutine.resume(event)
             }
         }
         coroutine.invokeOnCancellation {
-            deregister()
+            if (resumed.compareAndSet(false, true)) {
+                deregister()
+            }
         }
     }
 


### PR DESCRIPTION
The longer I played, the more laggy I got.
[Spark profiler](https://spark.lucko.me/m3ekxD7jvf?hl=105254,119045,119058)
The MSPT slowly crept up the longer I played.
Some Skytils events were taking upwards of 7000000ms.
Turns out, `gg.skytils.skytilsmod.core.TickKt$tickTask$1$invokeSuspend$$inlined$await$default` just kept growing in instances and size the longer I played.

I found that coroutines were only deregistered on cancellation, which is probably why they piled up.

This pr deregisters them before resuming, and the MSPT seems much more consistent now.