### PR TITLE
Fix: tooltip colors (in some situations)

### DIFF
--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/Skytils.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/Skytils.kt
@@ -166,6 +166,9 @@ object Skytils : CoroutineScope, EventSubscriber {
     var usingSBA = false
 
     @JvmField
+    var usingAaronMod = false
+
+    @JvmField
     var jarFile: File? = null
     private var lastChatMessage = 0L
 
@@ -420,6 +423,7 @@ object Skytils : CoroutineScope, EventSubscriber {
         usingLabymod = isModLoaded("labymod")
         usingNEU = isModLoaded("notenoughupdates")
         usingSBA = isModLoaded("skyblockaddons")
+        usingAaronMod = isModLoaded("aaron-mod")
 
         MayorInfo.fetchMayorData()
 

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
@@ -45,33 +45,33 @@ object EnchantNames : EventSubscriber, PersistentSave(File(Skytils.modDir, "ench
         if (replacements.count() == 0) return
         event.tooltip.replaceAll {
             var line = it.formattedText
+            var replacedAnything = false
             enchantRegex.findAll(
                 line
             ).forEach { result ->
                 val color = result.groups["color"]!!.value
                 val enchant = result.groups["enchant"]!!.value
+                if (replacements[enchant] == null) return@forEach
                 val level = result.groups["level"]!!.value
                 val suffix = result.groups["suffix"]?.value ?: ""
                 if (DevTools.getToggle("enchantNames")) {
                     println(enchant)
                     println(result.groups)
                 }
+                replacedAnything = true
                 line = line.replace(
                     result.value,
                     buildString {
                         append(color)
                         if (DevTools.getToggle("enchantNames")) append("{")
-                        if (replacements[enchant] != null)
-                            append("§o${enchant.replaceEnchantNames()}")
-                        else
-                            append(enchant)
+                        append("§o${enchant.replaceEnchantNames()}")
                         append(level)
                         if (DevTools.getToggle("enchantNames")) append("}")
                         append(suffix)
                     }
                 )
             }
-            textComponent(line)
+            if (replacedAnything) textComponent(line) else it
         }
     }
 

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
@@ -43,23 +43,21 @@ object EnchantNames : EventSubscriber, PersistentSave(File(Skytils.modDir, "ench
 
     fun onTooltip(event: ItemTooltipEvent) {
         if (replacements.isEmpty()) return
-        event.tooltip.replaceAll {
-            var line = it.formattedText
-            var replacedAnything = false
-            enchantRegex.findAll(
-                line
-            ).forEach { result ->
+        event.tooltip.replaceAll { line ->
+            val lineText = line.formattedText
+            val matches = enchantRegex.findAll(lineText)
+            if (matches.count() == 0) return@replaceAll line
+            matches.fold(lineText) { current, result ->
                 val color = result.groups["color"]!!.value
                 val enchant = result.groups["enchant"]!!.value
-                if (replacements[enchant] == null) return@forEach
+                if (replacements[enchant] == null) return@fold current
                 val level = result.groups["level"]!!.value
                 val suffix = result.groups["suffix"]?.value ?: ""
                 if (DevTools.getToggle("enchantNames")) {
                     println(enchant)
                     println(result.groups)
                 }
-                replacedAnything = true
-                line = line.replace(
+                current.replace(
                     result.value,
                     buildString {
                         append(color)
@@ -70,8 +68,7 @@ object EnchantNames : EventSubscriber, PersistentSave(File(Skytils.modDir, "ench
                         append(suffix)
                     }
                 )
-            }
-            if (replacedAnything) textComponent(line) else it
+            }.let(::textComponent)
         }
     }
 

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
@@ -42,7 +42,7 @@ object EnchantNames : EventSubscriber, PersistentSave(File(Skytils.modDir, "ench
     }
 
     fun onTooltip(event: ItemTooltipEvent) {
-        if (replacements.count() == 0) return
+        if (replacements.isEmpty()) return
         event.tooltip.replaceAll {
             var line = it.formattedText
             var replacedAnything = false

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/handlers/EnchantNames.kt
@@ -34,7 +34,7 @@ import java.io.Writer
 
 object EnchantNames : EventSubscriber, PersistentSave(File(Skytils.modDir, "enchantnames.json")) {
     private val enchantRegex =
-        Regex("(?<color>(?:§[0-9a-fzl]){1,2})(?<enchant> ?[\\w ]+[\\w \\-]*?)(?<level> [IVXLCDM0-9]{1,3})(?<suffix>§[9d], )?")
+        Regex("(?<color>(?:§[0-9a-fzlr]){1,2})(?<enchant> ?[\\w ]+[\\w \\-]*?)(?<level> [IVXLCDM0-9]{1,3})(?<suffix>§[9d], )?")
     val replacements = hashMapOf<String, String>()
 
     override fun setup() {
@@ -42,6 +42,7 @@ object EnchantNames : EventSubscriber, PersistentSave(File(Skytils.modDir, "ench
     }
 
     fun onTooltip(event: ItemTooltipEvent) {
+        if (replacements.count() == 0) return
         event.tooltip.replaceAll {
             var line = it.formattedText
             enchantRegex.findAll(

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/mcUtils.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/mcUtils.kt
@@ -139,13 +139,15 @@ fun formattingFromHex(hex: String): Formatting? {
 fun serializeFormattingToString(style: Style): String = buildString {
     style.color?.name
         ?.let { name ->
-            Formatting.byName(name)?.toString()
-                ?: if (Skytils.usingAaronMod && name.equals("#AA5500", ignoreCase = true)) {
-                    "§z"
-                } else {
-                    name.takeIf { it.startsWith('#') } // TODO: Support all hex codes with a custom system like §#
-                        ?.let(::formattingFromHex)
-                        ?.toString()
+            Formatting.byName(name)?.toString() // Done first because most text will use this
+                ?: when {
+                    Skytils.usingAaronMod && name.equals("#AA5500", ignoreCase = true) ->
+                        "§z"
+
+                    name.startsWith('#') ->
+                        formattingFromHex(name)?.toString() // TODO: Support all hex codes with a custom system like §#
+
+                    else -> null
                 }
         }
         ?.let(::append)

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/mcUtils.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/mcUtils.kt
@@ -129,12 +129,24 @@ val Text.formattedText: String
         siblings.forEach { append(it.formattedText) }
     }
 
+fun formattingFromHex(hex: String): Formatting? {
+    val colorInt = hex.removePrefix("#").toIntOrNull(16) ?: return null
+    return Formatting.entries.firstOrNull {
+        it.colorValue == colorInt
+    }
+}
 
 fun serializeFormattingToString(style: Style): String = buildString {
     style.color?.name
         ?.let { name ->
             Formatting.byName(name)?.toString()
-                ?: if (Skytils.usingAaronMod && name == "#AA5500") "§z" else null // TODO: Support all hex codes with a custom system
+                ?: if (Skytils.usingAaronMod && name.equals("#AA5500", ignoreCase = true)) {
+                    "§z"
+                } else {
+                    name.takeIf { it.startsWith('#') } // TODO: Support all hex codes with a custom system like §#
+                        ?.let(::formattingFromHex)
+                        ?.toString()
+                }
         }
         ?.let(::append)
     if (style.isBold) append("§l")

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/mcUtils.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/mcUtils.kt
@@ -20,6 +20,7 @@ package gg.skytils.skytilsmod.utils
 
 import gg.essential.elementa.unstable.state.v2.State
 import gg.essential.universal.wrappers.UPlayer
+import gg.skytils.skytilsmod.Skytils
 import net.minecraft.client.network.ClientPlayerEntity
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen
 import net.minecraft.item.ItemStack
@@ -130,7 +131,12 @@ val Text.formattedText: String
 
 
 fun serializeFormattingToString(style: Style): String = buildString {
-    style.color?.name?.let(Formatting::byName)?.let(::append)
+    style.color?.name
+        ?.let { name ->
+            Formatting.byName(name)?.toString()
+                ?: if (Skytils.usingAaronMod && name == "#AA5500") "§z" else null // TODO: Support all hex codes with a custom system
+        }
+        ?.let(::append)
     if (style.isBold) append("§l")
     if (style.isItalic) append("§o")
     if (style.isUnderlined) append("§n")


### PR DESCRIPTION
`formattedText` now supports:
- hex codes that are valid Minecraft formatting codes
- Aaron Mod's chroma

`onTooltip` now exits early if it won't do anything and only saves if changes were made.