### PR TITLE
[Feature] Glass Pane Desync Fix

### DIFF
--- a/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
+++ b/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
@@ -74,43 +74,39 @@ public abstract class MixinNetHandlerPlayClient implements ClientPlayPacketListe
         for (Direction dir : Direction.Type.HORIZONTAL) {
             BlockPos neighborPos = packet.getPos().offset(dir);
             BlockState neighborState = client.world.getBlockState(neighborPos);
-            if (neighborState.getBlock() instanceof net.minecraft.block.PaneBlock) {
+            if (neighborState.getBlock() instanceof PaneBlock) {
                 client.world.setBlockState(neighborPos, updateState(neighborPos, neighborState));
             }
         }
     }
 
     private BlockState updateState(BlockPos pos, BlockState state){
-        int count = 0;
+        int validConnect = 0;
         if (state.get(PaneBlock.NORTH)){
-            count++;
             if (client.world.getBlockState(pos.north()).isAir()){
-                count--;
                 state = state.with(PaneBlock.NORTH, false);
             }
+            else validConnect++;
         }
         if (state.get(PaneBlock.EAST)){
-            count++;
-            if (client.world.getBlockState(pos.east()).isAir()){
-                count--;
+            if (client.world.getBlockState(pos.east()).isAir()) {
                 state = state.with(PaneBlock.EAST, false);
             }
+            else validConnect++;
         }
         if (state.get(PaneBlock.SOUTH)){
-            count++;
             if (client.world.getBlockState(pos.south()).isAir()){
-                count--;
                 state = state.with(PaneBlock.SOUTH, false);
             }
+            else validConnect++;
         }
         if (state.get(PaneBlock.WEST)){
-            count++;
             if (client.world.getBlockState(pos.west()).isAir()){
-                count--;
                 state = state.with(PaneBlock.WEST, false);
             }
+            else validConnect++;
         }
-        if (count == 0){
+        if (validConnect == 0){
             state = state.with(PaneBlock.NORTH, true)
                     .with(PaneBlock.EAST, true)
                     .with(PaneBlock.SOUTH, true)

--- a/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
+++ b/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
@@ -24,6 +24,7 @@ import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.listener.ClientPlayPacketListener;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -80,6 +81,7 @@ public abstract class MixinNetHandlerPlayClient implements ClientPlayPacketListe
         }
     }
 
+    @Unique
     private BlockState updateState(BlockPos pos, BlockState state){
         int validConnect = 0;
         if (state.get(PaneBlock.NORTH)){

--- a/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
+++ b/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
@@ -28,6 +28,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+//# if MC>=10900
+import gg.skytils.skytilsmod.Skytils;
+import net.minecraft.block.PaneBlock;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.block.BlockState;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+//# endif
+
 //#if MC==10809
 //$$ import net.minecraft.network.packet.s2c.play.MobSpawnS2CPacket;
 //#else
@@ -52,4 +62,61 @@ public abstract class MixinNetHandlerPlayClient implements ClientPlayPacketListe
             MasterMode7Features.INSTANCE.onMobSpawned(entity);
         }
     }
+
+    //# if MC>=10900
+    private static final MinecraftClient client = MinecraftClient.getInstance();
+
+    @Inject(method = "onBlockUpdate", at = @At("TAIL"))
+    private void onBlockUpdate(BlockUpdateS2CPacket packet, CallbackInfo ci) {
+        if (client.world == null) return;
+        if (!Skytils.getConfig().getGlassPaneDesync()) return;
+
+        for (Direction dir : Direction.Type.HORIZONTAL) {
+            BlockPos neighborPos = packet.getPos().offset(dir);
+            BlockState neighborState = client.world.getBlockState(neighborPos);
+            if (neighborState.getBlock() instanceof net.minecraft.block.PaneBlock) {
+                client.world.setBlockState(neighborPos, updateState(neighborPos, neighborState));
+            }
+        }
+    }
+
+    private BlockState updateState(BlockPos pos, BlockState state){
+        int count = 0;
+        if (state.get(PaneBlock.NORTH)){
+            count++;
+            if (client.world.getBlockState(pos.north()).isAir()){
+                count--;
+                state = state.with(PaneBlock.NORTH, false);
+            }
+        }
+        if (state.get(PaneBlock.EAST)){
+            count++;
+            if (client.world.getBlockState(pos.east()).isAir()){
+                count--;
+                state = state.with(PaneBlock.EAST, false);
+            }
+        }
+        if (state.get(PaneBlock.SOUTH)){
+            count++;
+            if (client.world.getBlockState(pos.south()).isAir()){
+                count--;
+                state = state.with(PaneBlock.SOUTH, false);
+            }
+        }
+        if (state.get(PaneBlock.WEST)){
+            count++;
+            if (client.world.getBlockState(pos.west()).isAir()){
+                count--;
+                state = state.with(PaneBlock.WEST, false);
+            }
+        }
+        if (count == 0){
+            state = state.with(PaneBlock.NORTH, true)
+                    .with(PaneBlock.EAST, true)
+                    .with(PaneBlock.SOUTH, true)
+                    .with(PaneBlock.WEST, true);
+        }
+        return state;
+    }
+    //# endif
 }

--- a/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
+++ b/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
@@ -28,7 +28,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-//# if MC>=10900
+//# if MC>12000
 import gg.skytils.skytilsmod.Skytils;
 import net.minecraft.block.PaneBlock;
 import net.minecraft.client.MinecraftClient;
@@ -63,7 +63,7 @@ public abstract class MixinNetHandlerPlayClient implements ClientPlayPacketListe
         }
     }
 
-    //# if MC>=10900
+    //# if MC>12000
     private static final MinecraftClient client = MinecraftClient.getInstance();
 
     @Inject(method = "onBlockUpdate", at = @At("TAIL"))

--- a/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
+++ b/mod/src/main/java/gg/skytils/skytilsmod/mixins/transformers/network/MixinNetHandlerPlayClient.java
@@ -31,6 +31,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 //# if MC>12000
 import gg.skytils.skytilsmod.Skytils;
+import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.block.PaneBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.block.BlockState;
@@ -84,30 +85,16 @@ public abstract class MixinNetHandlerPlayClient implements ClientPlayPacketListe
     @Unique
     private BlockState updateState(BlockPos pos, BlockState state){
         int validConnect = 0;
-        if (state.get(PaneBlock.NORTH)){
-            if (client.world.getBlockState(pos.north()).isAir()){
-                state = state.with(PaneBlock.NORTH, false);
+        for (Direction dir : PaneBlock.FACING_PROPERTIES.keySet()){
+            BooleanProperty property = PaneBlock.FACING_PROPERTIES.get(dir);
+            if (state.get(property)){
+                if (client.world.getBlockState(pos.offset(dir)).isAir()){
+                    state = state.with(property, false);
+                }
+                else validConnect++;
             }
-            else validConnect++;
         }
-        if (state.get(PaneBlock.EAST)){
-            if (client.world.getBlockState(pos.east()).isAir()) {
-                state = state.with(PaneBlock.EAST, false);
-            }
-            else validConnect++;
-        }
-        if (state.get(PaneBlock.SOUTH)){
-            if (client.world.getBlockState(pos.south()).isAir()){
-                state = state.with(PaneBlock.SOUTH, false);
-            }
-            else validConnect++;
-        }
-        if (state.get(PaneBlock.WEST)){
-            if (client.world.getBlockState(pos.west()).isAir()){
-                state = state.with(PaneBlock.WEST, false);
-            }
-            else validConnect++;
-        }
+
         if (validConnect == 0){
             state = state.with(PaneBlock.NORTH, true)
                     .with(PaneBlock.EAST, true)

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -1882,7 +1882,7 @@ object Config : Vigilant(
     //# if MC>=10900
     @Property(
         type = PropertyType.SWITCH, name = "Glass Pane Desync Fix",
-        description = "Fixes glass pane connection desync in modern versions.",
+        description = "Fixes glass pane shape desync in modern versions.",
         category = "Mining", subcategory = "Quality of Life",
         i18nName = "skytils.config.mining.quality_of_life.glass_pane_desync_fix",
         i18nCategory = "skytils.config.mining",

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -1879,6 +1879,18 @@ object Config : Vigilant(
     )
     var showKuudraLowestBinPrice = false
 
+    //# if MC>=10900
+    @Property(
+        type = PropertyType.SWITCH, name = "Glass Pane Desync Fix",
+        description = "Fixes glass pane connection desync in modern versions.",
+        category = "Mining", subcategory = "Quality of Life",
+        i18nName = "skytils.config.mining.quality_of_life.glass_pane_desync_fix",
+        i18nCategory = "skytils.config.mining",
+        i18nSubcategory = "skytils.config.mining.quality_of_life"
+    )
+    var glassPaneDesync = false
+    //# endif
+
     @Property(
         type = PropertyType.SWITCH, name = "Dark Mode Mist",
         description = "Replaces colors in The Mist with darker variants.",

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -1879,7 +1879,7 @@ object Config : Vigilant(
     )
     var showKuudraLowestBinPrice = false
 
-    //# if MC>=10900
+    //# if MC>12000
     @Property(
         type = PropertyType.SWITCH, name = "Glass Pane Desync Fix",
         description = "Fixes glass pane shape desync in modern versions.",

--- a/mod/src/main/resources/assets/skytils/lang/en_US.lang
+++ b/mod/src/main/resources/assets/skytils/lang/en_US.lang
@@ -173,6 +173,7 @@ skytils.config.kuudra.price_checking.kuudra_chest_profit=Kuudra Chest Profit
 skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence=Kuudra Chest Profit Includes Essence
 skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key=Kuudra Chest Profit Subtracts Key
 skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price=Show Kuudra Lowest BIN Price
+skytils.config.mining.quality_of_life.glass_pane_desync_fix=Glass Pane Desync Fix
 skytils.config.mining.quality_of_life.dark_mode_mist=Dark Mode Mist
 skytils.config.mining.quality_of_life.highlight_completed_commissions=Highlight Completed Commissions
 skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks=Highlight Disabled HOTM Perks

--- a/mod/src/main/resources/assets/skytils/lang/en_us.json
+++ b/mod/src/main/resources/assets/skytils/lang/en_us.json
@@ -174,6 +174,7 @@
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence": "Kuudra Chest Profit Includes Essence",
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key": "Kuudra Chest Profit Subtracts Key",
     "skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price": "Show Kuudra Lowest BIN Price",
+    "skytils.config.mining.quality_of_life.glass_pane_desync_fix": "Glass Pane Desync Fix",
     "skytils.config.mining.quality_of_life.dark_mode_mist": "Dark Mode Mist",
     "skytils.config.mining.quality_of_life.highlight_completed_commissions": "Highlight Completed Commissions",
     "skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks": "Highlight Disabled HOTM Perks",

--- a/mod/src/main/resources/assets/skytils/lang/zh_CN.lang
+++ b/mod/src/main/resources/assets/skytils/lang/zh_CN.lang
@@ -167,6 +167,7 @@ skytils.config.kuudra.price_checking.kuudra_chest_profit=Kuudra宝箱利润
 skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence=Kuudra宝箱利润将包括精华
 skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key=Kuudra宝箱利润将扣除钥匙
 skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price=显示Kuudra最低一口价
+skytils.config.mining.quality_of_life.glass_pane_desync_fix=玻璃板不同步修复
 skytils.config.mining.quality_of_life.dark_mode_mist=深色模式的Mist区域
 skytils.config.mining.quality_of_life.highlight_completed_commissions=高亮已完成的委托
 skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks=高亮已禁用的HOTM特权

--- a/mod/src/main/resources/assets/skytils/lang/zh_TW.lang
+++ b/mod/src/main/resources/assets/skytils/lang/zh_TW.lang
@@ -167,6 +167,7 @@ skytils.config.kuudra.price_checking.kuudra_chest_profit=Kuudra寶箱利潤
 skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence=Kuudra寶箱利潤包含精華
 skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key=Kuudra寶箱利潤扣除鑰匙
 skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price=顯示Kuudra最低直購價
+skytils.config.mining.quality_of_life.glass_pane_desync_fix=玻璃板不同步修复
 skytils.config.mining.quality_of_life.dark_mode_mist=Mist區域深色模式
 skytils.config.mining.quality_of_life.highlight_completed_commissions=醒目顯示已完成的委託
 skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks=醒目顯示已停用的HOTM天賦

--- a/mod/src/main/resources/assets/skytils/lang/zh_cn.json
+++ b/mod/src/main/resources/assets/skytils/lang/zh_cn.json
@@ -168,6 +168,7 @@
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence": "Kuudra宝箱利润将包括精华",
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key": "Kuudra宝箱利润将扣除钥匙",
     "skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price": "显示Kuudra最低一口价",
+    "skytils.config.mining.quality_of_life.glass_pane_desync_fix": "玻璃板不同步修复",
     "skytils.config.mining.quality_of_life.dark_mode_mist": "深色模式的Mist区域",
     "skytils.config.mining.quality_of_life.highlight_completed_commissions": "高亮已完成的委托",
     "skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks": "高亮已禁用的HOTM特权",

--- a/mod/src/main/resources/assets/skytils/lang/zh_tw.json
+++ b/mod/src/main/resources/assets/skytils/lang/zh_tw.json
@@ -168,6 +168,7 @@
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence": "Kuudra寶箱利潤包含精華",
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key": "Kuudra寶箱利潤扣除鑰匙",
     "skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price": "顯示Kuudra最低直購價",
+    "skytils.config.mining.quality_of_life.glass_pane_desync_fix": "",
     "skytils.config.mining.quality_of_life.dark_mode_mist": "Mist區域深色模式",
     "skytils.config.mining.quality_of_life.highlight_completed_commissions": "醒目顯示已完成的委託",
     "skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks": "醒目顯示已停用的HOTM天賦",

--- a/mod/src/main/resources/assets/skytils/lang/zh_tw.json
+++ b/mod/src/main/resources/assets/skytils/lang/zh_tw.json
@@ -168,7 +168,7 @@
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_includes_essence": "Kuudra寶箱利潤包含精華",
     "skytils.config.kuudra.price_checking.kuudra_chest_profit_subtracts_key": "Kuudra寶箱利潤扣除鑰匙",
     "skytils.config.kuudra.price_checking.show_kuudra_lowest_bin_price": "顯示Kuudra最低直購價",
-    "skytils.config.mining.quality_of_life.glass_pane_desync_fix": "",
+    "skytils.config.mining.quality_of_life.glass_pane_desync_fix": "玻璃板不同步修复",
     "skytils.config.mining.quality_of_life.dark_mode_mist": "Mist區域深色模式",
     "skytils.config.mining.quality_of_life.highlight_completed_commissions": "醒目顯示已完成的委託",
     "skytils.config.mining.quality_of_life.highlight_disabled_hotm_perks": "醒目顯示已停用的HOTM天賦",


### PR DESCRIPTION
On modern versions (1.9+) glass pane shapes have changed
Hypixel doesnt seem to send neighbor block update packets when breaking a glass pane (in CH and perhaps glacite) so your client pane shape doesnt update

Added a feature [config.mining.quality_of_life.glass_pane_desync_fix | config.glassPaneDesync] that manually calculates the shape of a glass pane based on 1.8 shapes whenever block update packet is received