### PR TITLE
fix: getNbt

### DIFF
--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/multiplatform/nbt.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/multiplatform/nbt.kt
@@ -24,5 +24,5 @@ import kotlin.jvm.optionals.getOrNull
 
 val ItemStack.nbt
     get() =
-        if (this.isEmpty) null
-        else MinecraftClient.getInstance().player?.registryManager?.let(this::toNbt)?.asCompound()?.getOrNull()
+        if (isEmpty) null
+        else MinecraftClient.getInstance().player?.registryManager?.let(::toNbt)?.asCompound()?.getOrNull()

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/multiplatform/nbt.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/multiplatform/nbt.kt
@@ -25,4 +25,4 @@ import kotlin.jvm.optionals.getOrNull
 val ItemStack.nbt
     get() =
         if (this.isEmpty) null
-        else MinecraftClient.getInstance().player?.registryManager?.let(::toNbt)?.asCompound()?.getOrNull()
+        else MinecraftClient.getInstance().player?.registryManager?.let(this::toNbt)?.asCompound()?.getOrNull()

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/multiplatform/nbt.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/utils/multiplatform/nbt.kt
@@ -24,4 +24,5 @@ import kotlin.jvm.optionals.getOrNull
 
 val ItemStack.nbt
     get() =
-        MinecraftClient.getInstance().player?.registryManager?.let(::toNbt)?.asCompound()?.getOrNull()
+        if (this.isEmpty) null
+        else MinecraftClient.getInstance().player?.registryManager?.let(::toNbt)?.asCompound()?.getOrNull()


### PR DESCRIPTION
explicitly returns null if trying to get nbt of empty itemstack, which toNbt used to throw