### PR TITLE
Slayer and miniboss detection

### DIFF
--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
@@ -82,14 +82,14 @@ object SlayerFeatures : EventSubscriber, CoroutineScope {
     override val coroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher() + SupervisorJob()
 
     private val ZOMBIE_MINIBOSSES = arrayOf(
-        "§cRevenant Sycophant",
-        "§cRevenant Champion",
-        "§4Deformed Revenant",
-        "§cAtoned Champion",
-        "§4Atoned Revenant"
+        "Revenant Sycophant",
+        "Revenant Champion",
+        "Deformed Revenant",
+        "Atoned Champion",
+        "Atoned Revenant"
     )
-    private val SPIDER_MINIBOSSES = arrayOf("§cTarantula Vermin", "§cTarantula Beast", "§4Mutant Tarantula")
-    private val WOLF_MINIBOSSES = arrayOf("§cPack Enforcer", "§cSven Follower", "§4Sven Alpha")
+    private val SPIDER_MINIBOSSES = arrayOf("Tarantula Vermin", "Tarantula Beast", "Mutant Tarantula")
+    private val WOLF_MINIBOSSES = arrayOf("Pack Enforcer", "Sven Follower", "Sven Alpha")
     private val ENDERMAN_MINIBOSSES = arrayOf("Voidling Devotee", "Voidling Radical", "Voidcrazed Maniac")
     private val BLAZE_MINIBOSSES = arrayOf("Flare Demon", "Kindleheart Demon", "Burningsoul Demon")
 
@@ -256,7 +256,7 @@ object SlayerFeatures : EventSubscriber, CoroutineScope {
             val entity = event.entity as ArmorStandEntity
             if (!entity.hasCustomName()) return
             val name = entity.displayName?.string ?: return
-            if (Skytils.config.slayerBossHitbox && name.endsWith("§c❤") && !name.endsWith("§e0§c❤") && !mc.entityRenderDispatcher.shouldRenderHitboxes()) {
+            if (Skytils.config.slayerBossHitbox && name.endsWith("❤") && !name.endsWith(" 0❤") && !mc.entityRenderDispatcher.shouldRenderHitboxes()) {
                 val (x, y, z) = RenderUtil.fixRenderPos(event.x, event.y, event.z)
                 if (ZOMBIE_MINIBOSSES.any { name.contains(it) } || BLAZE_MINIBOSSES.any { name.contains(it) }) {
                     drawOutlinedBoundingBox(

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
@@ -97,7 +97,7 @@ object SlayerFeatures : EventSubscriber, CoroutineScope {
     // but that requires a more extensive testing of all skyblock timers,
     // something I am not quite particularly fond of doing
     internal val timerRegex =
-        Regex("(?:§[8bef]§l(ASHEN|CRYSTAL|AURIC|SPIRIT)§[8bef] ♨\\d |§4§lIMMUNE )?§c\\d+:\\d+(?:§r)?")
+        Regex("(?:§r)?(?:§[8bef]§l(ASHEN|CRYSTAL|AURIC|SPIRIT)§[8bef] ♨\\d |§4§lIMMUNE )?§c\\d+:\\d+(?:§r)?")
     internal val totemRegex = Regex("§6§l(?<time>\\d+)s §c§l(?<hits>\\d+) hits")
     var slayer: Slayer<*>? = null
         set(value) {

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/SlayerFeatures.kt
@@ -117,8 +117,8 @@ object SlayerFeatures : EventSubscriber, CoroutineScope {
         slayer = try {
             when (entity) {
                 is ZombieEntity -> RevenantSlayer(entity)
-                is SpiderEntity -> Slayer(entity, "Tarantula Broodfather", "§5☠ §4Tarantula Broodfather")
-                is WolfEntity -> Slayer(entity, "Sven Packmaster", "§c☠ §fSven Packmaster")
+                is SpiderEntity -> Slayer(entity, "Tarantula Broodfather", "§4Tarantula Broodfather")
+                is WolfEntity -> Slayer(entity, "Sven Packmaster", "§fSven Packmaster")
                 is EndermanEntity -> SeraphSlayer(entity)
                 is BlazeEntity -> DemonlordSlayer(entity)
                 is OtherClientPlayerEntity -> {

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/base/Slayer.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/base/Slayer.kt
@@ -42,7 +42,7 @@ import net.minecraft.item.ItemStack
 open class Slayer<T : LivingEntity>(
     val entity: T,
     private val name: String,
-    private vararg val nameStart: String,
+    private vararg val nameContains: String,
 ) {
     var nameEntity: ArmorStandEntity? = null
     var timerEntity: ArmorStandEntity? = null
@@ -84,7 +84,7 @@ open class Slayer<T : LivingEntity>(
             for (nearby in nearbyArmorStands) {
                 when {
                     nearby.displayName?.formattedText?.startsWith("§8[§7Lv") == true -> continue
-                    nameStart.any { nearby.displayName?.formattedText?.startsWith(it) == true } -> {
+                    nameContains.any { nearby.displayName?.formattedText?.contains(it) == true } -> {
                         printDevMessage(
                             { "expected tier $currentTier, hp $expectedHealth - spawned hp ${entity.baseMaxHealth.toInt()}" },
                             "slayer"

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/base/ThrowingSlayer.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/base/ThrowingSlayer.kt
@@ -29,8 +29,8 @@ import net.minecraft.util.math.BlockPos
  *
  * Subtype of [Slayer]
  */
-abstract class ThrowingSlayer<T : MobEntity>(entity: T, name: String, nameStart: String) : Slayer<T>(
-    entity, name, nameStart,
+abstract class ThrowingSlayer<T : MobEntity>(entity: T, name: String, nameContains: String) : Slayer<T>(
+    entity, name, nameContains,
 ) {
     var thrownLocation: BlockPos? = null
     var thrownEntity: ArmorStandEntity? = null

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/DemonlordSlayer.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/DemonlordSlayer.kt
@@ -52,7 +52,7 @@ import net.minecraft.util.math.BlockPos
 import java.awt.Color
 
 class DemonlordSlayer(entity: BlazeEntity) :
-    ThrowingSlayer<BlazeEntity>(entity, "Inferno Demonlord", "§c☠ §bInferno Demonlord") {
+    ThrowingSlayer<BlazeEntity>(entity, "Inferno Demonlord", "§bInferno Demonlord") {
     var totemEntity: ArmorStandEntity? = null
     var totemPos: BlockPos? = null
 

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/RevenantSlayer.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/RevenantSlayer.kt
@@ -33,7 +33,7 @@ import net.minecraft.registry.tag.BlockTags
 import net.minecraft.util.math.BlockPos
 
 class RevenantSlayer(entity: ZombieEntity) :
-    Slayer<ZombieEntity>(entity, "Revenant Horror", "§c☠ §bRevenant Horror", "§c☠ §fAtoned Horror") {
+    Slayer<ZombieEntity>(entity, "Revenant Horror", "§bRevenant Horror", "§fAtoned Horror") {
 
     override fun set() {
         rev5PingTask.start()

--- a/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/SeraphSlayer.kt
+++ b/mod/src/main/kotlin/gg/skytils/skytilsmod/features/impl/slayer/impl/SeraphSlayer.kt
@@ -41,7 +41,7 @@ import net.minecraft.util.math.Box
 import kotlin.math.abs
 
 class SeraphSlayer(entity: EndermanEntity) :
-    ThrowingSlayer<EndermanEntity>(entity, "Voidgloom Seraph", "§c☠ §bVoidgloom Seraph") {
+    ThrowingSlayer<EndermanEntity>(entity, "Voidgloom Seraph", "§bVoidgloom Seraph") {
     val nukekebiSkulls = mutableListOf<ArmorStandEntity>()
     var yangGlyphAdrenalineStressCount = -1L
     var lastYangGlyphSwitch = -1L


### PR DESCRIPTION
Fix: Detection for minibosses by removing the color codes which aren't present in entity.displayName?.string
Fix: Slayer detection by using contains instead of startsWith so that even if hypixel changes their mobtypes again it won't instantly break

Doesn't fix any of the rendering issues 