### PR TITLE
feat: item stars display

### DIFF
--- a/src/main/java/gg/skytils/skytilsmod/mixins/item/MixinItemStack.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/item/MixinItemStack.java
@@ -1,0 +1,25 @@
+package gg.skytils.skytilsmod.mixins.item;
+
+import gg.skytils.skytilsmod.hooks.ItemStackHookKt;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemStack.class)
+public abstract class MixinItemStack {
+    @Shadow
+    public abstract @Nullable Text getCustomName();
+
+    @Shadow
+    public abstract Text getItemName();
+
+    @Inject(method = "getName", at = @At("HEAD"), cancellable = true)
+    public void getName(CallbackInfoReturnable<Text> cir) {
+        cir.setReturnValue(ItemStackHookKt.modifyDisplayName(this.getCustomName() != null ? this.getCustomName() : this.getItemName()));
+    }
+}

--- a/src/main/java/gg/skytils/skytilsmod/mixins/item/MixinItemStack.java
+++ b/src/main/java/gg/skytils/skytilsmod/mixins/item/MixinItemStack.java
@@ -1,6 +1,9 @@
 package gg.skytils.skytilsmod.mixins.item;
 
+import gg.essential.universal.utils.TextUtilsKt;
+import gg.skytils.skytilsmod.core.Config;
 import gg.skytils.skytilsmod.hooks.ItemStackHookKt;
+import gg.skytils.skytilsmod.util.SBInfo;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import org.jspecify.annotations.Nullable;
@@ -20,6 +23,10 @@ public abstract class MixinItemStack {
 
     @Inject(method = "getName", at = @At("HEAD"), cancellable = true)
     public void getName(CallbackInfoReturnable<Text> cir) {
-        cir.setReturnValue(ItemStackHookKt.modifyDisplayName(this.getCustomName() != null ? this.getCustomName() : this.getItemName()));
+        if (!SBInfo.INSTANCE.getSkyblockState().getUntracked() || Config.INSTANCE.getStarDisplayType() == 0) return;
+        Text displayName = this.getCustomName() != null ? this.getCustomName() : this.getItemName();
+        if (!TextUtilsKt.toUnformattedString(displayName).contains(ItemStackHookKt.star)) return;
+
+        cir.setReturnValue(ItemStackHookKt.modifyStarDisplay(displayName));
     }
 }

--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -58,6 +58,14 @@ object Config : Vigilant(
     )
     var droppedItemScale = 1f
 
+    @Property(
+        type = PropertyType.SELECTOR, name = "Item Stars Display",
+        description = "Changes the way Item Stars are displayed on Items.",
+        category = "Miscellaneous", subcategory = "Items",
+        options = ["Normal", "Old", "Compact"]
+    )
+    var starDisplayType = 0
+
     fun init() {
         initialize()
         lastLaunchedVersion = Reference.VERSION

--- a/src/main/kotlin/gg/skytils/skytilsmod/hooks/ItemStackHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/hooks/ItemStackHook.kt
@@ -1,0 +1,61 @@
+package gg.skytils.skytilsmod.hooks
+
+import gg.essential.universal.utils.toUnformattedString
+import gg.skytils.skytilsmod.core.Config
+import gg.skytils.skytilsmod.util.SBInfo
+import net.minecraft.text.Text
+import net.minecraft.util.Formatting
+
+const val star = '✪'
+val masterStars = ('➊'..'➎').map { it.toString() }
+
+fun modifyDisplayName(displayName: Text): Text {
+    if (!SBInfo.skyblockState.getUntracked() || Config.starDisplayType == 0 || !displayName.toUnformattedString().contains(star)) return displayName
+
+    val out = Text.empty().setStyle(displayName.style)
+    val siblings = displayName.siblings
+
+    var i = 0
+    while (i < siblings.size) {
+        val current = siblings[i]
+        val stars = current.starCount()
+
+        if (stars > 0) {
+            val masters = siblings.getOrNull(i + 1)?.masterStarCount() ?: 0
+
+            // 1 = Old, 2 = Compact, 0 = Disabled
+            when (Config.starDisplayType) {
+                1 -> {
+                    out.append(current)
+
+                    if (masters > 0) {
+                        out.append(Text.literal(star.toString().repeat(masters)).formatted(Formatting.RED))
+                    }
+                }
+
+                2 -> {
+                    val total = stars + masters
+                    val color = if (total > 5) Formatting.RED else Formatting.GOLD
+                    out.append(Text.literal("$total$star").formatted(color))
+                }
+            }
+
+            siblings.subList(i + if (masters > 0) 2 else 1, siblings.size).forEach { out.append(it) }
+
+            break
+        }
+
+        out.append(current)
+        i++
+    }
+
+    return out
+}
+
+private fun Text.starCount(): Int {
+    return string.count { it == star }
+}
+
+private fun Text.masterStarCount(): Int {
+    return masterStars.indexOfFirst { it == string } + 1
+}

--- a/src/main/kotlin/gg/skytils/skytilsmod/hooks/ItemStackHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/hooks/ItemStackHook.kt
@@ -1,17 +1,13 @@
 package gg.skytils.skytilsmod.hooks
 
-import gg.essential.universal.utils.toUnformattedString
 import gg.skytils.skytilsmod.core.Config
-import gg.skytils.skytilsmod.util.SBInfo
 import net.minecraft.text.Text
 import net.minecraft.util.Formatting
 
-const val star = '✪'
+const val star = "✪"
 val masterStars = ('➊'..'➎').map { it.toString() }
 
-fun modifyDisplayName(displayName: Text): Text {
-    if (!SBInfo.skyblockState.getUntracked() || Config.starDisplayType == 0 || !displayName.toUnformattedString().contains(star)) return displayName
-
+fun modifyStarDisplay(displayName: Text): Text {
     val out = Text.empty().setStyle(displayName.style)
     val siblings = displayName.siblings
 
@@ -26,10 +22,14 @@ fun modifyDisplayName(displayName: Text): Text {
             // 1 = Old, 2 = Compact, 0 = Disabled
             when (Config.starDisplayType) {
                 1 -> {
-                    out.append(current)
-
                     if (masters > 0) {
-                        out.append(Text.literal(star.toString().repeat(masters)).formatted(Formatting.RED))
+                        val masterStarText = Text.literal(star.repeat(masters)).formatted(Formatting.RED)
+                        val normalStarText = Text.literal(star.repeat(stars - masters)).formatted(Formatting.GOLD)
+
+                        out.append(masterStarText)
+                        out.append(normalStarText)
+                    } else {
+                        out.append(current)
                     }
                 }
 
@@ -53,7 +53,7 @@ fun modifyDisplayName(displayName: Text): Text {
 }
 
 private fun Text.starCount(): Int {
-    return string.count { it == star }
+    return string.count { it.toString() == star }
 }
 
 private fun Text.masterStarCount(): Int {

--- a/src/main/kotlin/gg/skytils/skytilsmod/hooks/ItemStackHook.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/hooks/ItemStackHook.kt
@@ -23,11 +23,15 @@ fun modifyStarDisplay(displayName: Text): Text {
             when (Config.starDisplayType) {
                 1 -> {
                     if (masters > 0) {
+                        val diff = stars - masters
                         val masterStarText = Text.literal(star.repeat(masters)).formatted(Formatting.RED)
-                        val normalStarText = Text.literal(star.repeat(stars - masters)).formatted(Formatting.GOLD)
+                        val normalStarText = Text.literal(star.repeat(diff)).formatted(Formatting.GOLD)
 
                         out.append(masterStarText)
-                        out.append(normalStarText)
+
+                        if (diff > 0) {
+                            out.append(normalStarText)
+                        }
                     } else {
                         out.append(current)
                     }

--- a/src/main/resources/mixins.skytils.json
+++ b/src/main/resources/mixins.skytils.json
@@ -5,7 +5,8 @@
   "refmap": "mixins.skytils.refmap.json",
   "mixins": [
     "events.MainThreadPacket_MixinPacketApplyBatcherEntry",
-    "events.MixinClientConnection"
+    "events.MixinClientConnection",
+    "item.MixinItemStack"
   ],
   "mixinextras": {
     "minVersion": "0.5.3"


### PR DESCRIPTION
while it works, I don't think Injecting ItemStack#getName is the most performant idea (may be better to just do it specifically for HandledScreen Tooltip Rendering and InGameHud Item Name Popup)

<img width="733" height="374" alt="image" src="https://github.com/user-attachments/assets/13b26438-73d5-4d4a-814b-5410b10db507" />
<img width="701" height="346" alt="image" src="https://github.com/user-attachments/assets/a2d66cc5-d9d4-4a7c-9080-8f4d53a7a985" />