### PR TITLE
Stop auto-set Crystal Hollows waypoints from drifting after being set

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/CHWaypoints.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/mining/CHWaypoints.kt
@@ -248,7 +248,7 @@ object CHWaypoints {
             if (!corleone.loc.exists()) {
                 corleone.loc.set()
                 corleone.sendThroughWS()
-            } else corleone.loc.set()
+            }
         }
     }
 
@@ -262,7 +262,7 @@ object CHWaypoints {
                 if (!it.loc.exists()) {
                     it.loc.set()
                     it.sendThroughWS()
-                } else it.loc.set()
+                }
             }
         } else if (waypointDelayTicks > 0)
             waypointDelayTicks--


### PR DESCRIPTION
## Summary
- Fixes #301 — auto-set Crystal Hollows waypoints (Corleone and the other named locations resolved via `SBInfo.location`) slowly shift position, sometimes out of the actual structure, the longer you stay near them and move around. Player-set waypoints are unaffected.
- Root cause: in both `onRenderLivingPre()` (Corleone) and `onTick()` (the other locations), the `if (!loc.exists()) { loc.set(); ... } else loc.set()` structure calls `loc.set()` in **both** branches — including after the location has already been established.
- `LocationObject.set()` works by narrowing a running min/max bounding box toward the *player's current position* each time it's called (see `LocationObject` at the bottom of the file: `locMinX = (player.posX - 200).coerceIn(...).coerceAtMost(locMinX)`, etc., then `locX = (locMinX + locMaxX) / 2`). That's a reasonable way to narrow down a not-yet-visible target's position over time, but it should only run *before* the location is known — calling it again every tick after `exists()` is already true keeps recomputing the center based on wherever the player currently stands, so the "locked in" waypoint drifts as the player walks around nearby, exactly matching the report (worse "the longer you stay out of a main structure" and specifically when moving around after having looked at it).
- Player-set waypoints go through `setExact()` once and are never touched again, which is why they don't exhibit this — matching the issue's observation that only auto-set ones shift.

## Fix
- Remove the `else loc.set()` / `} else corleone.loc.set()` calls in both spots, so the position is computed once on first detection (when `exists()` is false) and never recomputed afterward — matching what the existing `if (!exists())` structure already implies was intended.

## Test plan
- [x] Confirmed via `LocationObject.set()`'s implementation that it's a position-narrowing routine driven by the player's current coordinates, not an idempotent re-confirmation, so calling it repeatedly after the location is already resolved is the actual mechanism of the drift.
- [x] Change is a 2-line removal with no other behavior change; `sendThroughWS()` (broadcasting the found location over the mod's websocket) still only fires once, on first detection, same as before.
- Not able to reproduce inside a live Hypixel Crystal Hollows session in this environment, so please confirm the waypoint stays put after being found before merging.